### PR TITLE
chore(changelog): update for 0.1.1 (CI + Flyway + TS fixes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ This format follows Keep a Changelog and adheres to Semantic Versioning where pr
 
 ## [Unreleased]
 
+## 0.1.1 — 2025-10-01
+### Added
+- CI: 新增 `frontend-lint`（ESLint）與 `backend-test`（Gradle 測試）工作，與既有 build 分離並行。
+
+### Changed
+- DB/Flyway：重整為新基準（V1：users/categories/accounts；V2：預設使用者），移除舊有相互衝突的遷移。注意：本地需以 `docker compose down -v` 重置資料卷後重啟。
+- CI：`backend-docker-build` 保留僅建置，不推送影像；整體工作拆分更清晰。
+
+### Fixed
+- Frontend：修正 TypeScript `verbatimModuleSyntax` 與 `erasableSyntaxOnly` 導致的匯入/enum 問題；移除 `any` 用法以通過 ESLint。
+
+### Chore / Docs
+- Compose：移除過時的 `version: '3.8'` 欄位以消除警告。
+- 文件：README 新增 CI 章節；DevOps 指南補充本倉庫 CI 現況與本機等效指令；本地開發指南新增 Flyway 基準重置說明。
+
 ## 0.1.0 — 2025-09-14
 ### Added
 - README 更新為 MVP 規格


### PR DESCRIPTION
- Added: frontend-lint, backend-test CI jobs
- Changed: Flyway baseline to V1/V2; requires local volume reset
- Fixed: TS verbatimModuleSyntax/erasableSyntaxOnly + ESLint issues
- Chore/Docs: remove compose version key; README/DevOps/Local-setup updates