### PR TITLE
feat(transactions): create transaction API + UI (MVP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,72 @@
 
 > 啟動時遇到問題？請參考 [本地開發設定指南](docs/local-setup-guide.md)。
 
+## 12.1 MVP：Transactions API（建立交易）
+
+本階段提供建立「收入 / 支出 / 轉帳」交易的 API（僅限單幣別）。
+
+- 端點：`POST /api/transactions`
+- 通用欄位：`userId`, `kind ∈ {INCOME,EXPENSE,TRANSFER}`, `amount>0`, `occurredAt(ISO8601)`, `notes?`, `currencyCode(3)`
+- 類型特定欄位：
+  - INCOME/EXPENSE：`accountId`（必填），`categoryId?`
+  - TRANSFER：`sourceAccountId` + `targetAccountId`（皆必填、且不可相同）
+
+範例請求：
+
+收入（INCOME）
+```json
+{
+  "userId": "00000000-0000-0000-0000-000000000001",
+  "kind": "INCOME",
+  "amount": 1000.00,
+  "occurredAt": "2025-01-01T00:00:00Z",
+  "accountId": "<ACCOUNT_ID>",
+  "categoryId": "<CATEGORY_ID>",
+  "notes": "Salary",
+  "currencyCode": "TWD"
+}
+```
+
+支出（EXPENSE）
+```json
+{
+  "userId": "00000000-0000-0000-0000-000000000001",
+  "kind": "EXPENSE",
+  "amount": 250.50,
+  "occurredAt": "2025-01-03T00:00:00Z",
+  "accountId": "<ACCOUNT_ID>",
+  "categoryId": "<CATEGORY_ID>",
+  "notes": "Lunch",
+  "currencyCode": "TWD"
+}
+```
+
+轉帳（TRANSFER）
+```json
+{
+  "userId": "00000000-0000-0000-0000-000000000001",
+  "kind": "TRANSFER",
+  "amount": 500.00,
+  "occurredAt": "2025-01-05T00:00:00Z",
+  "sourceAccountId": "<SRC_ACCOUNT_ID>",
+  "targetAccountId": "<DST_ACCOUNT_ID>",
+  "notes": "Move funds",
+  "currencyCode": "TWD"
+}
+```
+
+標準錯誤格式（例）：
+```json
+{
+  "error": "ValidationError",
+  "message": "來源帳戶與目標帳戶不可相同"
+}
+```
+
+限制（MVP）：
+- 僅支援單一幣別；跨幣交易會被 400 拒絕。
+- 信用卡特殊規則（結帳/繳款）尚未納入，先以一般加減計入帳戶餘額。
+
 ## 13. CI（持續整合）
 
 本倉庫使用 GitHub Actions 進行最小可行驗證（前後端分開、可並行）：
@@ -127,6 +193,7 @@
 ## 文件與連結
 - ADR-001：前後端技術棧決策 — docs/adr/ADR-001-tech-stack.md
 - ADR-002：部署策略 — docs/adr/ADR-002-deployment.md
+- Transactions API — docs/api/transactions.md
 - 技術草圖（C4-L1/L2/L3＋ERD）— docs/architecture/technical-sketch.md
 - Roadmap — docs/roadmap.md
 - Changelog — CHANGELOG.md

--- a/backend/src/main/java/com/example/pocketfolio/controller/TransactionController.java
+++ b/backend/src/main/java/com/example/pocketfolio/controller/TransactionController.java
@@ -1,0 +1,39 @@
+package com.example.pocketfolio.controller;
+
+import com.example.pocketfolio.dto.CreateTransactionRequest;
+import com.example.pocketfolio.dto.TransactionDto;
+import com.example.pocketfolio.entity.Transaction;
+import com.example.pocketfolio.service.TransactionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/transactions")
+@RequiredArgsConstructor
+public class TransactionController {
+
+    private final TransactionService transactionService;
+
+    @PostMapping
+    public ResponseEntity<TransactionDto> create(@RequestBody CreateTransactionRequest request) {
+        Transaction tx = transactionService.createTransaction(request);
+        TransactionDto dto = TransactionDto.builder()
+                .id(tx.getId())
+                .userId(tx.getUserId())
+                .kind(tx.getKind())
+                .amount(tx.getAmount())
+                .occurredAt(tx.getOccurredAt())
+                .accountId(tx.getAccount() != null ? tx.getAccount().getId() : null)
+                .sourceAccountId(tx.getSourceAccount() != null ? tx.getSourceAccount().getId() : null)
+                .targetAccountId(tx.getTargetAccount() != null ? tx.getTargetAccount().getId() : null)
+                .categoryId(tx.getCategory() != null ? tx.getCategory().getId() : null)
+                .notes(tx.getNotes())
+                .currencyCode(tx.getCurrencyCode())
+                .fxRateUsed(tx.getFxRateUsed())
+                .build();
+        return new ResponseEntity<>(dto, HttpStatus.CREATED);
+    }
+}
+

--- a/backend/src/main/java/com/example/pocketfolio/dto/CreateTransactionRequest.java
+++ b/backend/src/main/java/com/example/pocketfolio/dto/CreateTransactionRequest.java
@@ -1,0 +1,29 @@
+package com.example.pocketfolio.dto;
+
+import com.example.pocketfolio.entity.TransactionKind;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Setter
+public class CreateTransactionRequest {
+    private UUID userId;
+    private TransactionKind kind;
+    private BigDecimal amount;
+    private Instant occurredAt;
+
+    private UUID accountId; // for income/expense
+    private UUID sourceAccountId; // for transfer
+    private UUID targetAccountId; // for transfer
+
+    private UUID categoryId; // optional for income/expense
+    private String notes;
+
+    private String currencyCode; // required: MVP same-currency only
+    private BigDecimal fxRateUsed; // optional, reserved
+}
+

--- a/backend/src/main/java/com/example/pocketfolio/dto/TransactionDto.java
+++ b/backend/src/main/java/com/example/pocketfolio/dto/TransactionDto.java
@@ -1,0 +1,33 @@
+package com.example.pocketfolio.dto;
+
+import com.example.pocketfolio.entity.TransactionKind;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class TransactionDto {
+    private UUID id;
+    private UUID userId;
+    private TransactionKind kind;
+    private BigDecimal amount;
+    private Instant occurredAt;
+    private UUID accountId;
+    private UUID sourceAccountId;
+    private UUID targetAccountId;
+    private UUID categoryId;
+    private String notes;
+    private String currencyCode;
+    private BigDecimal fxRateUsed;
+}
+

--- a/backend/src/main/java/com/example/pocketfolio/entity/Transaction.java
+++ b/backend/src/main/java/com/example/pocketfolio/entity/Transaction.java
@@ -1,0 +1,75 @@
+package com.example.pocketfolio.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "transactions")
+public class Transaction {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "kind", nullable = false, length = 20)
+    private TransactionKind kind;
+
+    @Column(name = "amount", nullable = false, precision = 18, scale = 2)
+    private BigDecimal amount;
+
+    @Column(name = "occurred_at", nullable = false)
+    private Instant occurredAt;
+
+    // For income/expense
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id")
+    private Account account;
+
+    // For transfer
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "source_account_id")
+    private Account sourceAccount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "target_account_id")
+    private Account targetAccount;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @Column(name = "notes", length = 1000)
+    private String notes;
+
+    @Column(name = "currency_code", nullable = false, length = 3)
+    private String currencyCode;
+
+    @Column(name = "fx_rate_used", precision = 18, scale = 6)
+    private BigDecimal fxRateUsed;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}
+

--- a/backend/src/main/java/com/example/pocketfolio/entity/TransactionKind.java
+++ b/backend/src/main/java/com/example/pocketfolio/entity/TransactionKind.java
@@ -1,0 +1,8 @@
+package com.example.pocketfolio.entity;
+
+public enum TransactionKind {
+    INCOME,
+    EXPENSE,
+    TRANSFER
+}
+

--- a/backend/src/main/java/com/example/pocketfolio/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/example/pocketfolio/exception/GlobalExceptionHandler.java
@@ -1,0 +1,42 @@
+package com.example.pocketfolio.exception;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    private ResponseEntity<Map<String, Object>> build(HttpStatus status, String error, String message) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("error", error);
+        body.put("message", message);
+        return ResponseEntity.status(status).body(body);
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    public ResponseEntity<Map<String, Object>> handleNotFound(NotFoundException ex) {
+        return build(HttpStatus.NOT_FOUND, "NotFound", ex.getMessage());
+    }
+
+    @ExceptionHandler({IllegalArgumentException.class})
+    public ResponseEntity<Map<String, Object>> handleValidation(IllegalArgumentException ex) {
+        return build(HttpStatus.BAD_REQUEST, "ValidationError", ex.getMessage());
+    }
+
+    @ExceptionHandler(DataIntegrityViolationException.class)
+    public ResponseEntity<Map<String, Object>> handleConstraint(DataIntegrityViolationException ex) {
+        return build(HttpStatus.BAD_REQUEST, "ConstraintViolation", ex.getMostSpecificCause().getMessage());
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, Object>> handleOthers(Exception ex) {
+        return build(HttpStatus.INTERNAL_SERVER_ERROR, "ServerError", ex.getMessage());
+    }
+}
+

--- a/backend/src/main/java/com/example/pocketfolio/exception/NotFoundException.java
+++ b/backend/src/main/java/com/example/pocketfolio/exception/NotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.pocketfolio.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}
+

--- a/backend/src/main/java/com/example/pocketfolio/repository/TransactionRepository.java
+++ b/backend/src/main/java/com/example/pocketfolio/repository/TransactionRepository.java
@@ -1,0 +1,12 @@
+package com.example.pocketfolio.repository;
+
+import com.example.pocketfolio.entity.Transaction;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface TransactionRepository extends JpaRepository<Transaction, UUID> {
+}
+

--- a/backend/src/main/java/com/example/pocketfolio/service/TransactionService.java
+++ b/backend/src/main/java/com/example/pocketfolio/service/TransactionService.java
@@ -1,0 +1,126 @@
+package com.example.pocketfolio.service;
+
+import com.example.pocketfolio.dto.CreateTransactionRequest;
+import com.example.pocketfolio.entity.*;
+import com.example.pocketfolio.exception.NotFoundException;
+import com.example.pocketfolio.repository.AccountRepository;
+import com.example.pocketfolio.repository.CategoryRepository;
+import com.example.pocketfolio.repository.TransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class TransactionService {
+
+    private final TransactionRepository transactionRepository;
+    private final AccountRepository accountRepository;
+    private final CategoryRepository categoryRepository;
+
+    @Transactional
+    public Transaction createTransaction(CreateTransactionRequest req) {
+        if (req.getUserId() == null) {
+            throw new IllegalArgumentException("userId is required");
+        }
+        if (req.getKind() == null) {
+            throw new IllegalArgumentException("kind is required");
+        }
+        if (req.getAmount() == null || req.getAmount().compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("amount must be greater than 0");
+        }
+        if (req.getOccurredAt() == null) {
+            throw new IllegalArgumentException("occurredAt is required");
+        }
+        if (req.getCurrencyCode() == null || req.getCurrencyCode().length() != 3) {
+            throw new IllegalArgumentException("currencyCode (3-letter) is required");
+        }
+
+        Transaction tx = new Transaction();
+        tx.setUserId(req.getUserId());
+        tx.setKind(req.getKind());
+        tx.setAmount(req.getAmount());
+        tx.setOccurredAt(req.getOccurredAt());
+        tx.setNotes(req.getNotes());
+        tx.setCurrencyCode(req.getCurrencyCode());
+        tx.setFxRateUsed(req.getFxRateUsed());
+
+        if (req.getCategoryId() != null) {
+            Category category = categoryRepository.findById(req.getCategoryId())
+                    .orElseThrow(() -> new NotFoundException("Category not found: " + req.getCategoryId()));
+            tx.setCategory(category);
+        }
+
+        switch (req.getKind()) {
+            case INCOME -> handleIncomeExpense(tx, req.getAccountId(), true);
+            case EXPENSE -> handleIncomeExpense(tx, req.getAccountId(), false);
+            case TRANSFER -> handleTransfer(tx, req.getSourceAccountId(), req.getTargetAccountId());
+        }
+
+        return transactionRepository.save(tx);
+    }
+
+    private void handleIncomeExpense(Transaction tx, UUID accountId, boolean isIncome) {
+        if (accountId == null) {
+            throw new IllegalArgumentException("accountId is required for income/expense");
+        }
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new NotFoundException("Account not found: " + accountId));
+        if (account.isArchived()) {
+            throw new IllegalArgumentException("Account is archived and cannot accept transactions");
+        }
+        ensureSameCurrency(tx.getCurrencyCode(), account.getCurrencyCode());
+
+        BigDecimal amount = tx.getAmount();
+        BigDecimal newBalance = account.getCurrentBalance();
+        newBalance = isIncome ? newBalance.add(amount) : newBalance.subtract(amount);
+        account.setCurrentBalance(newBalance);
+
+        tx.setAccount(account);
+        tx.setSourceAccount(null);
+        tx.setTargetAccount(null);
+    }
+
+    private void handleTransfer(Transaction tx, UUID sourceId, UUID targetId) {
+        if (sourceId == null || targetId == null) {
+            throw new IllegalArgumentException("sourceAccountId and targetAccountId are required for transfer");
+        }
+        if (Objects.equals(sourceId, targetId)) {
+            throw new IllegalArgumentException("來源帳戶與目標帳戶不可相同");
+        }
+
+        Account source = accountRepository.findById(sourceId)
+                .orElseThrow(() -> new NotFoundException("Source account not found: " + sourceId));
+        Account target = accountRepository.findById(targetId)
+                .orElseThrow(() -> new NotFoundException("Target account not found: " + targetId));
+
+        if (source.isArchived() || target.isArchived()) {
+            throw new IllegalArgumentException("Source/Target account is archived and cannot accept transactions");
+        }
+
+        // MVP: only same currency transfers
+        ensureSameCurrency(tx.getCurrencyCode(), source.getCurrencyCode());
+        ensureSameCurrency(source.getCurrencyCode(), target.getCurrencyCode());
+
+        BigDecimal amount = tx.getAmount();
+
+        source.setCurrentBalance(source.getCurrentBalance().subtract(amount));
+        target.setCurrentBalance(target.getCurrentBalance().add(amount));
+
+        tx.setAccount(null);
+        tx.setSourceAccount(source);
+        tx.setTargetAccount(target);
+        tx.setCategory(null); // category ignored for transfer in MVP
+    }
+
+    private void ensureSameCurrency(String a, String b) {
+        if (a == null || b == null || !a.equalsIgnoreCase(b)) {
+            throw new IllegalArgumentException("跨幣別交易尚未支援（MVP 限單一幣別）");
+        }
+    }
+}
+

--- a/backend/src/main/resources/db/migration/V3__create_transactions.sql
+++ b/backend/src/main/resources/db/migration/V3__create_transactions.sql
@@ -1,0 +1,51 @@
+-- V3: Create transactions table for MVP (income/expense/transfer)
+
+CREATE TABLE transactions (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL,
+    occurred_at TIMESTAMPTZ NOT NULL,
+    kind VARCHAR(20) NOT NULL,
+    amount DECIMAL(18,2) NOT NULL CHECK (amount > 0),
+
+    -- For income/expense
+    account_id UUID,
+
+    -- For transfer
+    source_account_id UUID,
+    target_account_id UUID,
+
+    category_id UUID,
+    notes TEXT,
+
+    currency_code VARCHAR(3) NOT NULL,
+    fx_rate_used DECIMAL(18,6),
+
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_tx_user FOREIGN KEY (user_id) REFERENCES users(id),
+    CONSTRAINT fk_tx_account FOREIGN KEY (account_id) REFERENCES accounts(id),
+    CONSTRAINT fk_tx_source FOREIGN KEY (source_account_id) REFERENCES accounts(id),
+    CONSTRAINT fk_tx_target FOREIGN KEY (target_account_id) REFERENCES accounts(id),
+    CONSTRAINT fk_tx_category FOREIGN KEY (category_id) REFERENCES categories(id),
+
+    CONSTRAINT chk_tx_kind CHECK (kind IN ('INCOME','EXPENSE','TRANSFER')),
+    -- Non-transfer: require account_id and no source/target
+    CONSTRAINT chk_tx_income_expense CHECK (
+        (kind IN ('INCOME','EXPENSE') AND account_id IS NOT NULL AND source_account_id IS NULL AND target_account_id IS NULL)
+        OR kind = 'TRANSFER'
+    ),
+    -- Transfer: require both source/target and they must differ; account_id must be NULL
+    CONSTRAINT chk_tx_transfer CHECK (
+        (kind = 'TRANSFER' AND account_id IS NULL AND source_account_id IS NOT NULL AND target_account_id IS NOT NULL AND source_account_id <> target_account_id)
+        OR kind IN ('INCOME','EXPENSE')
+    )
+);
+
+CREATE INDEX idx_transactions_user ON transactions(user_id);
+CREATE INDEX idx_transactions_occurred_at ON transactions(occurred_at);
+CREATE INDEX idx_transactions_kind ON transactions(kind);
+CREATE INDEX idx_transactions_account ON transactions(account_id);
+CREATE INDEX idx_transactions_source ON transactions(source_account_id);
+CREATE INDEX idx_transactions_target ON transactions(target_account_id);
+

--- a/docs/api/transactions.md
+++ b/docs/api/transactions.md
@@ -1,0 +1,68 @@
+# Transactions API（MVP）
+
+建立「收入 / 支出 / 轉帳」交易，並同步更新帳戶餘額（MVP：直接更新 `current_balance`）。
+
+- 端點：`POST /api/transactions`
+- `Content-Type: application/json`
+
+## 請求欄位
+
+通用：
+- `userId: UUID`（必填）
+- `kind: "INCOME" | "EXPENSE" | "TRANSFER"`（必填）
+- `amount: number (> 0)`（必填）
+- `occurredAt: ISO8601`（必填）
+- `notes?: string`
+- `currencyCode: string(3)`（必填；MVP 僅支援單幣別）
+- `fxRateUsed?: number`（預留）
+
+INCOME / EXPENSE：
+- `accountId: UUID`（必填）
+- `categoryId?: UUID`
+
+TRANSFER：
+- `sourceAccountId: UUID`（必填）
+- `targetAccountId: UUID`（必填；且不可與 `sourceAccountId` 相同）
+
+## 回應
+
+`201 Created`，回傳建立完成的交易摘要：
+```json
+{
+  "id": "UUID",
+  "userId": "UUID",
+  "kind": "INCOME",
+  "amount": 1000.00,
+  "occurredAt": "2025-01-01T00:00:00Z",
+  "accountId": "UUID",
+  "sourceAccountId": null,
+  "targetAccountId": null,
+  "categoryId": "UUID",
+  "notes": "...",
+  "currencyCode": "TWD",
+  "fxRateUsed": null
+}
+```
+
+## 錯誤格式
+
+`400 Bad Request` 等：
+```json
+{ "error": "ValidationError", "message": "..." }
+```
+
+## 商業規則（MVP）
+
+- INCOME：帳戶餘額 `+ amount`
+- EXPENSE：帳戶餘額 `- amount`
+- TRANSFER：來源 `- amount`、目標 `+ amount`
+- 帳戶不可為 `archived`
+- 僅支援單幣別；跨幣交易會被拒絕（400）
+- 轉帳來源與目標不可相同
+
+## 之後（非 MVP）
+
+- `GET /api/transactions?from=&to=` 取得區間交易
+- idempotency key 防重複提交
+- 多幣別與匯率、信用卡結帳/扣款規則
+

--- a/docs/local-setup-guide.md
+++ b/docs/local-setup-guide.md
@@ -47,3 +47,12 @@ services:
    ```
 
 不想刪除資料？請勿使用 `-v`，並手動比對/調整既有資料表結構；但此路徑需自行承擔資料不一致風險。
+
+## 新增：Transactions 交易表（V3）
+
+此版本新增 `V3__create_transactions.sql`（`transactions` 表）。若你先前有啟動過資料庫，Flyway 會自動套用 V3 遷移。若遇到遷移失敗或本地資料與新約束衝突，建議清空 volume 後重建：
+
+```bash
+docker-compose down -v
+docker-compose up -d --build
+```

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import './App.css';
 import { CategoryPage } from './pages/CategoryPage';
 import { AccountPage } from './pages/AccountPage';
+import { TransactionsPage } from './pages/TransactionsPage';
 import { useState, useEffect } from 'react';
 
 function App() {
@@ -18,6 +19,9 @@ function App() {
 
   let PageComponent;
   switch (currentPage) {
+    case '#/transactions':
+      PageComponent = TransactionsPage;
+      break;
     case '#/accounts':
       PageComponent = AccountPage;
       break;
@@ -31,7 +35,8 @@ function App() {
     <div className="App">
       <nav>
         <a href="#/categories">分類管理</a> |
-        <a href="#/accounts">帳戶管理</a>
+        <a href="#/accounts">帳戶管理</a> |
+        <a href="#/transactions">交易</a>
       </nav>
       <hr />
       <PageComponent />

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -1,0 +1,224 @@
+import { useEffect, useMemo, useState } from 'react';
+import type { ChangeEvent, FormEvent } from 'react';
+
+const API_TX = 'http://localhost:8080/api/transactions';
+const API_ACCOUNTS = 'http://localhost:8080/api/accounts';
+const API_CATEGORIES = 'http://localhost:8080/api/categories';
+
+type Kind = 'INCOME' | 'EXPENSE' | 'TRANSFER';
+
+interface Account {
+  id: string;
+  name: string;
+  type: string;
+  currencyCode: string;
+  currentBalance: number;
+  archived: boolean;
+}
+
+interface CategoryNode {
+  id: string;
+  name: string;
+  children?: CategoryNode[];
+}
+
+const todayStr = () => {
+  const d = new Date();
+  const yyyy = d.getFullYear();
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const dd = String(d.getDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+};
+
+function flattenCategories(categories: CategoryNode[]): { id: string; name: string; level: number }[] {
+  const out: { id: string; name: string; level: number }[] = [];
+  const walk = (nodes: CategoryNode[], level: number) => {
+    for (const n of nodes) {
+      out.push({ id: n.id, name: n.name, level });
+      if (n.children && n.children.length) walk(n.children, level + 1);
+    }
+  };
+  walk(categories, 0);
+  return out;
+}
+
+export function TransactionsPage() {
+  const [kind, setKind] = useState<Kind>('INCOME');
+  const [date, setDate] = useState<string>(todayStr());
+  const [amount, setAmount] = useState<number>(0);
+  const [accountId, setAccountId] = useState<string>('');
+  const [sourceAccountId, setSourceAccountId] = useState<string>('');
+  const [targetAccountId, setTargetAccountId] = useState<string>('');
+  const [categoryId, setCategoryId] = useState<string>('');
+  const [notes, setNotes] = useState<string>('');
+
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [categories, setCategories] = useState<CategoryNode[]>([]);
+  const flatCategories = useMemo(() => flattenCategories(categories), [categories]);
+
+  useEffect(() => {
+    const fetchAll = async () => {
+      try {
+        const [accRes, catRes] = await Promise.all([
+          fetch(API_ACCOUNTS),
+          fetch(API_CATEGORIES),
+        ]);
+        if (!accRes.ok) throw new Error('Failed to load accounts');
+        if (!catRes.ok) throw new Error('Failed to load categories');
+        const accData: Account[] = await accRes.json();
+        const catData: CategoryNode[] = await catRes.json();
+        setAccounts(accData);
+        setCategories(catData);
+        if (accData.length && !accountId) setAccountId(accData[0].id);
+        if (accData.length && !sourceAccountId) setSourceAccountId(accData[0].id);
+        if (accData.length > 1 && !targetAccountId) setTargetAccountId(accData[1].id);
+      } catch (e) {
+        console.error(e);
+        alert('載入帳戶/分類資料失敗');
+      }
+    };
+    fetchAll();
+  }, []);
+
+  const onSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (amount <= 0) {
+      alert('金額需大於 0');
+      return;
+    }
+
+    // Hardcoded user for MVP
+    const userId = '00000000-0000-0000-0000-000000000001';
+
+    const occurredAt = new Date(`${date}T00:00:00`).toISOString();
+
+    const findAcc = (id: string) => accounts.find(a => a.id === id);
+
+    let payload: any = {
+      userId,
+      kind,
+      amount,
+      occurredAt,
+      notes: notes || null,
+    };
+
+    if (kind === 'INCOME' || kind === 'EXPENSE') {
+      const acc = findAcc(accountId);
+      if (!acc) {
+        alert('請選擇帳戶');
+        return;
+      }
+      payload.accountId = accountId;
+      payload.currencyCode = acc.currencyCode;
+      if (categoryId) payload.categoryId = categoryId;
+    } else {
+      const source = findAcc(sourceAccountId);
+      const target = findAcc(targetAccountId);
+      if (!source || !target) {
+        alert('請選擇來源與目標帳戶');
+        return;
+      }
+      payload.sourceAccountId = sourceAccountId;
+      payload.targetAccountId = targetAccountId;
+      payload.currencyCode = source.currencyCode; // must match target in backend
+    }
+
+    try {
+      const res = await fetch(API_TX, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        // Standard error format { error, message }
+        let message = await res.text();
+        try {
+          const json = JSON.parse(message);
+          if (json && json.message) message = json.message;
+        } catch {}
+        throw new Error(message);
+      }
+      setAmount(0);
+      setNotes('');
+      alert('交易已建立');
+    } catch (err) {
+      console.error(err);
+      alert(`建立交易失敗：${err instanceof Error ? err.message : String(err)}`);
+    }
+  };
+
+  const onNumber = (setter: (n: number) => void) =>
+    (e: ChangeEvent<HTMLInputElement>) => setter(parseFloat(e.target.value || '0'));
+
+  return (
+    <div>
+      <h1>建立交易</h1>
+      <form onSubmit={onSubmit}>
+        <div>
+          <label>日期：</label>
+          <input type="date" value={date} onChange={(e) => setDate(e.target.value)} required />
+        </div>
+        <div>
+          <label>類型：</label>
+          <label><input type="radio" name="kind" value="INCOME" checked={kind==='INCOME'} onChange={() => setKind('INCOME')} /> 收入</label>
+          <label><input type="radio" name="kind" value="EXPENSE" checked={kind==='EXPENSE'} onChange={() => setKind('EXPENSE')} /> 支出</label>
+          <label><input type="radio" name="kind" value="TRANSFER" checked={kind==='TRANSFER'} onChange={() => setKind('TRANSFER')} /> 轉帳</label>
+        </div>
+        <div>
+          <label>金額：</label>
+          <input type="number" value={amount} onChange={onNumber(setAmount)} step="0.01" min="0.01" required />
+        </div>
+
+        {kind !== 'TRANSFER' ? (
+          <div>
+            <label>帳戶：</label>
+            <select value={accountId} onChange={(e) => setAccountId(e.target.value)} required>
+              {accounts.map(a => (
+                <option key={a.id} value={a.id}>{a.name} ({a.currencyCode})</option>
+              ))}
+            </select>
+          </div>
+        ) : (
+          <>
+            <div>
+              <label>來源帳戶：</label>
+              <select value={sourceAccountId} onChange={(e) => setSourceAccountId(e.target.value)} required>
+                {accounts.map(a => (
+                  <option key={a.id} value={a.id}>{a.name} ({a.currencyCode})</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label>目標帳戶：</label>
+              <select value={targetAccountId} onChange={(e) => setTargetAccountId(e.target.value)} required>
+                {accounts.map(a => (
+                  <option key={a.id} value={a.id}>{a.name} ({a.currencyCode})</option>
+                ))}
+              </select>
+            </div>
+          </>
+        )}
+
+        {kind !== 'TRANSFER' && (
+          <div>
+            <label>分類（可選）：</label>
+            <select value={categoryId} onChange={(e) => setCategoryId(e.target.value)}>
+              <option value="">-- 無 --</option>
+              {flatCategories.map(c => (
+                <option key={c.id} value={c.id}>{'--'.repeat(c.level)} {c.name}</option>
+              ))}
+            </select>
+          </div>
+        )}
+
+        <div>
+          <label>備註：</label>
+          <input type="text" value={notes} onChange={(e) => setNotes(e.target.value)} />
+        </div>
+
+        <button type="submit">建立</button>
+      </form>
+    </div>
+  );
+}
+


### PR DESCRIPTION
- 新增 V3 交易表與約束（income/expense/transfer）
- 後端：Transaction entity/repo/service/controller；統一錯誤格式
- 前端：TransactionsPage 建立收入/支出/轉帳；App 導覽更新
- 文件：README 12.1、docs/api/transactions.md、local-setup-guide 補充