### PR TITLE
feat(transactions): GET list by date range + monthly calendar with create/delete

### DIFF
--- a/backend/src/main/java/com/example/pocketfolio/controller/TransactionController.java
+++ b/backend/src/main/java/com/example/pocketfolio/controller/TransactionController.java
@@ -62,4 +62,10 @@ public class TransactionController {
                 .fxRateUsed(tx.getFxRateUsed())
                 .build();
     }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable UUID id) {
+        transactionService.deleteTransaction(id);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/backend/src/main/java/com/example/pocketfolio/controller/TransactionController.java
+++ b/backend/src/main/java/com/example/pocketfolio/controller/TransactionController.java
@@ -32,6 +32,7 @@ public class TransactionController {
     }
 
     @GetMapping
+    @org.springframework.transaction.annotation.Transactional(readOnly = true)
     public ResponseEntity<Page<TransactionDto>> list(
             @RequestParam(required = false) UUID userId,
             @RequestParam(required = false) Instant from,

--- a/backend/src/main/java/com/example/pocketfolio/controller/TransactionController.java
+++ b/backend/src/main/java/com/example/pocketfolio/controller/TransactionController.java
@@ -5,9 +5,17 @@ import com.example.pocketfolio.dto.TransactionDto;
 import com.example.pocketfolio.entity.Transaction;
 import com.example.pocketfolio.service.TransactionService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/transactions")
@@ -19,7 +27,26 @@ public class TransactionController {
     @PostMapping
     public ResponseEntity<TransactionDto> create(@RequestBody CreateTransactionRequest request) {
         Transaction tx = transactionService.createTransaction(request);
-        TransactionDto dto = TransactionDto.builder()
+        TransactionDto dto = toDto(tx);
+        return new ResponseEntity<>(dto, HttpStatus.CREATED);
+    }
+
+    @GetMapping
+    public ResponseEntity<Page<TransactionDto>> list(
+            @RequestParam(required = false) UUID userId,
+            @RequestParam(required = false) Instant from,
+            @RequestParam(required = false) Instant to,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "50") int size
+    ) {
+        Page<Transaction> p = transactionService.listTransactions(userId, from, to, PageRequest.of(page, size));
+        List<TransactionDto> dtos = p.getContent().stream().map(this::toDto).collect(Collectors.toList());
+        Page<TransactionDto> dtoPage = new PageImpl<>(dtos, p.getPageable(), p.getTotalElements());
+        return ResponseEntity.ok(dtoPage);
+    }
+
+    private TransactionDto toDto(Transaction tx) {
+        return TransactionDto.builder()
                 .id(tx.getId())
                 .userId(tx.getUserId())
                 .kind(tx.getKind())
@@ -33,7 +60,5 @@ public class TransactionController {
                 .currencyCode(tx.getCurrencyCode())
                 .fxRateUsed(tx.getFxRateUsed())
                 .build();
-        return new ResponseEntity<>(dto, HttpStatus.CREATED);
     }
 }
-

--- a/backend/src/main/java/com/example/pocketfolio/repository/TransactionRepository.java
+++ b/backend/src/main/java/com/example/pocketfolio/repository/TransactionRepository.java
@@ -1,12 +1,15 @@
 package com.example.pocketfolio.repository;
 
 import com.example.pocketfolio.entity.Transaction;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
 import java.util.UUID;
 
 @Repository
 public interface TransactionRepository extends JpaRepository<Transaction, UUID> {
+    Page<Transaction> findByUserIdAndOccurredAtBetweenOrderByOccurredAtAsc(UUID userId, Instant from, Instant to, Pageable pageable);
 }
-

--- a/backend/src/main/java/com/example/pocketfolio/service/TransactionService.java
+++ b/backend/src/main/java/com/example/pocketfolio/service/TransactionService.java
@@ -7,10 +7,13 @@ import com.example.pocketfolio.repository.AccountRepository;
 import com.example.pocketfolio.repository.CategoryRepository;
 import com.example.pocketfolio.repository.TransactionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -122,5 +125,12 @@ public class TransactionService {
             throw new IllegalArgumentException("跨幣別交易尚未支援（MVP 限單一幣別）");
         }
     }
-}
 
+    @Transactional(readOnly = true)
+    public Page<Transaction> listTransactions(UUID userId, Instant from, Instant to, Pageable pageable) {
+        UUID uid = (userId != null) ? userId : UUID.fromString("00000000-0000-0000-0000-000000000001");
+        Instant start = (from != null) ? from : Instant.EPOCH;
+        Instant end = (to != null) ? to : Instant.now();
+        return transactionRepository.findByUserIdAndOccurredAtBetweenOrderByOccurredAtAsc(uid, start, end, pageable);
+    }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import './App.css';
 import { CategoryPage } from './pages/CategoryPage';
 import { AccountPage } from './pages/AccountPage';
 import { TransactionsPage } from './pages/TransactionsPage';
+import { TransactionsCalendarPage } from './pages/TransactionsCalendarPage';
 import { useState, useEffect } from 'react';
 
 function App() {
@@ -19,6 +20,9 @@ function App() {
 
   let PageComponent;
   switch (currentPage) {
+    case '#/calendar':
+      PageComponent = TransactionsCalendarPage;
+      break;
     case '#/transactions':
       PageComponent = TransactionsPage;
       break;
@@ -36,7 +40,8 @@ function App() {
       <nav>
         <a href="#/categories">分類管理</a> |
         <a href="#/accounts">帳戶管理</a> |
-        <a href="#/transactions">交易</a>
+        <a href="#/transactions">交易</a> |
+        <a href="#/calendar">月曆</a>
       </nav>
       <hr />
       <PageComponent />

--- a/frontend/src/pages/TransactionsCalendarPage.tsx
+++ b/frontend/src/pages/TransactionsCalendarPage.tsx
@@ -208,6 +208,34 @@ export function TransactionsCalendarPage() {
     } catch {}
   };
 
+  const reloadMonth = async () => {
+    try {
+      const res = await fetch(`${API_TX}?from=${encodeURIComponent(fromISO)}&to=${encodeURIComponent(toISO)}&page=0&size=500`);
+      if (res.ok) {
+        const data = await res.json();
+        const list: TxItem[] = (data.content ?? data) as TxItem[];
+        setItems(list);
+      }
+    } catch {}
+  };
+
+  const deleteTx = async (id: string) => {
+    if (!confirm('確定要刪除這筆交易嗎？')) return;
+    try {
+      const res = await fetch(`${API_TX}/${id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        let message = await res.text();
+        try { const j: { message?: string } = JSON.parse(message); if (j.message) message = j.message; } catch { void 0; }
+        alert(`刪除失敗：${message}`);
+        return;
+      }
+      await reloadMonth();
+    } catch (e) {
+      console.error(e);
+      alert('刪除失敗');
+    }
+  };
+
   return (
     <div>
       <h1>交易月曆</h1>
@@ -265,7 +293,10 @@ export function TransactionsCalendarPage() {
                         <div>{cat || '—'}</div>
                         <div>{it.kind === 'TRANSFER' ? (<>{src ?? '來源?'} → {dst ?? '目標?'}</>) : (acc ?? '帳戶?')}</div>
                         <div style={{ color: '#555', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{it.notes || '—'}</div>
-                        <div>{userName}</div>
+                        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+                          <span>{userName}</span>
+                          <button onClick={() => deleteTx(it.id)} style={{ padding: '2px 6px', border: '1px solid #d32f2f', color: '#d32f2f', background: '#fff', borderRadius: 4, cursor: 'pointer' }}>刪除</button>
+                        </div>
                       </div>
                     );
                   })}

--- a/frontend/src/pages/TransactionsCalendarPage.tsx
+++ b/frontend/src/pages/TransactionsCalendarPage.tsx
@@ -259,10 +259,38 @@ export function TransactionsCalendarPage() {
               )}
             </div>
             <div>
-              <label>類型：</label>
-              <label><input type="radio" name="kind" value="INCOME" checked={kind==='INCOME'} onChange={() => setKind('INCOME')} /> 收入</label>
-              <label><input type="radio" name="kind" value="EXPENSE" checked={kind==='EXPENSE'} onChange={() => setKind('EXPENSE')} /> 支出</label>
-              <label><input type="radio" name="kind" value="TRANSFER" checked={kind==='TRANSFER'} onChange={() => setKind('TRANSFER')} /> 轉帳</label>
+              <div style={{ marginBottom: 6, fontSize: 12, color: '#555' }}>交易類型：</div>
+              <div role="tablist" aria-label="交易類型" style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+                {([
+                  { key: 'INCOME' as Kind, label: '收入', symbol: '+', color: '#138a36' },
+                  { key: 'EXPENSE' as Kind, label: '支出', symbol: '−', color: '#c62828' },
+                  { key: 'TRANSFER' as Kind, label: '轉帳', symbol: '↔', color: '#1565c0' },
+                ]).map(opt => (
+                  <button
+                    key={opt.key}
+                    type="button"
+                    role="tab"
+                    aria-selected={kind === opt.key}
+                    onClick={() => setKind(opt.key)}
+                    title={opt.label}
+                    style={{
+                      padding: '6px 10px',
+                      borderRadius: 6,
+                      border: kind === opt.key ? `2px solid ${opt.color}` : '1px solid #ccc',
+                      background: kind === opt.key ? `${opt.color}15` : '#fff',
+                      color: opt.color,
+                      fontWeight: 600,
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 6,
+                      cursor: 'pointer'
+                    }}
+                  >
+                    <span aria-hidden>{opt.symbol}</span>
+                    <span>{opt.label}</span>
+                  </button>
+                ))}
+              </div>
             </div>
             <div>
               <label>金額：</label>

--- a/frontend/src/pages/TransactionsCalendarPage.tsx
+++ b/frontend/src/pages/TransactionsCalendarPage.tsx
@@ -230,10 +230,11 @@ export function TransactionsCalendarPage() {
                 <div style={{ fontSize: 12, color: '#777' }}>當日尚無交易</div>
               ) : (
                 <div>
-                  <div style={{ display: 'grid', gridTemplateColumns: '120px 1fr 1fr 120px', gap: 8, fontSize: 12, fontWeight: 600, color: '#444', paddingBottom: 6, borderBottom: '1px solid #f2f2f2' }}>
+                  <div style={{ display: 'grid', gridTemplateColumns: '120px 1fr 1fr 1fr 120px', gap: 8, fontSize: 12, fontWeight: 600, color: '#333', paddingBottom: 6, borderBottom: '1px solid #f2f2f2' }}>
                     <div>金額</div>
                     <div>類別</div>
                     <div>帳戶/來源→目標</div>
+                    <div>備註</div>
                     <div>使用者</div>
                   </div>
                   {itemsOfSelectedDay.map((it) => {
@@ -245,10 +246,11 @@ export function TransactionsCalendarPage() {
                     const cat = it.categoryId ? categoryMap.get(it.categoryId) : '';
                     const userName = '';
                     return (
-                      <div key={it.id} style={{ display: 'grid', gridTemplateColumns: '120px 1fr 1fr 120px', gap: 8, alignItems: 'center', padding: '6px 0', borderBottom: '1px solid #f7f7f7' }}>
+                      <div key={it.id} style={{ display: 'grid', gridTemplateColumns: '120px 1fr 1fr 1fr 120px', gap: 8, alignItems: 'center', padding: '6px 0', borderBottom: '1px solid #f7f7f7' }}>
                         <div style={{ color, fontWeight: 700 }}>{sign}{it.amount.toLocaleString()}</div>
                         <div>{cat || '—'}</div>
                         <div>{it.kind === 'TRANSFER' ? (<>{src ?? '來源?'} → {dst ?? '目標?'}</>) : (acc ?? '帳戶?')}</div>
+                        <div style={{ color: '#555', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{it.notes || '—'}</div>
                         <div>{userName}</div>
                       </div>
                     );

--- a/frontend/src/pages/TransactionsCalendarPage.tsx
+++ b/frontend/src/pages/TransactionsCalendarPage.tsx
@@ -1,0 +1,250 @@
+import { useEffect, useMemo, useState } from 'react';
+
+const API_TX = 'http://localhost:8080/api/transactions';
+const API_ACCOUNTS = 'http://localhost:8080/api/accounts';
+const API_CATEGORIES = 'http://localhost:8080/api/categories';
+
+type Kind = 'INCOME' | 'EXPENSE' | 'TRANSFER';
+
+interface TxItem {
+  id: string;
+  kind: Kind;
+  amount: number;
+  occurredAt: string; // ISO
+}
+
+interface Account { id: string; name: string; currencyCode: string; archived: boolean; type: string; currentBalance: number; }
+interface CategoryNode { id: string; name: string; children?: CategoryNode[] }
+
+function startOfMonth(d: Date) { return new Date(d.getFullYear(), d.getMonth(), 1); }
+function endOfMonth(d: Date) { return new Date(d.getFullYear(), d.getMonth() + 1, 0); }
+function addMonths(d: Date, n: number) { return new Date(d.getFullYear(), d.getMonth() + n, 1); }
+function toIsoStart(z: Date) { return new Date(Date.UTC(z.getFullYear(), z.getMonth(), z.getDate(), 0, 0, 0)).toISOString(); }
+function toIsoNextDay(z: Date) { return new Date(Date.UTC(z.getFullYear(), z.getMonth(), z.getDate() + 1, 0, 0, 0)).toISOString(); }
+function ymd(d: Date) { return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`; }
+
+export function TransactionsCalendarPage() {
+  const [cursor, setCursor] = useState<Date>(startOfMonth(new Date()));
+  const [items, setItems] = useState<TxItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  // Modal state
+  const [open, setOpen] = useState(false);
+  const [selectedDate, setSelectedDate] = useState<string>(''); // YYYY-MM-DD
+
+  // Form state (lightweight, similar to TransactionsPage)
+  const [kind, setKind] = useState<Kind>('INCOME');
+  const [amount, setAmount] = useState<number>(0);
+  const [accountId, setAccountId] = useState<string>('');
+  const [sourceAccountId, setSourceAccountId] = useState<string>('');
+  const [targetAccountId, setTargetAccountId] = useState<string>('');
+  const [categoryId, setCategoryId] = useState<string>('');
+  const [notes, setNotes] = useState<string>('');
+  const [accounts, setAccounts] = useState<Account[]>([]);
+  const [categories, setCategories] = useState<CategoryNode[]>([]);
+
+  const monthStart = startOfMonth(cursor);
+  const monthEnd = endOfMonth(cursor);
+  const fromISO = toIsoStart(monthStart);
+  const toISO = toIsoNextDay(new Date(monthEnd));
+
+  useEffect(() => {
+    const fetchMonth = async () => {
+      setLoading(true);
+      try {
+        const res = await fetch(`${API_TX}?from=${encodeURIComponent(fromISO)}&to=${encodeURIComponent(toISO)}&page=0&size=500`);
+        if (!res.ok) throw new Error('Failed to load transactions');
+        const data = await res.json();
+        const list: TxItem[] = (data.content ?? data) as TxItem[]; // support Page or array
+        setItems(list);
+      } catch (e) {
+        console.error(e);
+        alert('載入交易失敗');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchMonth();
+  }, [fromISO, toISO]);
+
+  useEffect(() => {
+    const fetchRefs = async () => {
+      try {
+        const [accRes, catRes] = await Promise.all([
+          fetch(API_ACCOUNTS), fetch(API_CATEGORIES)
+        ]);
+        if (!accRes.ok) throw new Error('Failed to load accounts');
+        if (!catRes.ok) throw new Error('Failed to load categories');
+        const accData: Account[] = await accRes.json();
+        const catData: CategoryNode[] = await catRes.json();
+        setAccounts(accData);
+        setCategories(catData);
+        if (accData.length) {
+          setAccountId(accData[0].id);
+          setSourceAccountId(accData[0].id);
+          setTargetAccountId(accData[1]?.id ?? accData[0].id);
+        }
+      } catch (e) {
+        console.error(e);
+      }
+    };
+    fetchRefs();
+  }, []);
+
+  const countsByDay = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const it of items) {
+      const d = new Date(it.occurredAt);
+      const key = ymd(new Date(d.getFullYear(), d.getMonth(), d.getDate()));
+      map.set(key, (map.get(key) ?? 0) + 1);
+    }
+    return map;
+  }, [items]);
+
+  const daysGrid = useMemo(() => {
+    const firstWeekday = new Date(monthStart.getFullYear(), monthStart.getMonth(), 1).getDay();
+    const totalDays = monthEnd.getDate();
+    const cells: Array<{ date: Date | null }>= [];
+    for (let i=0;i<firstWeekday;i++) cells.push({ date: null });
+    for (let d=1; d<=totalDays; d++) cells.push({ date: new Date(monthStart.getFullYear(), monthStart.getMonth(), d) });
+    while (cells.length % 7 !== 0) cells.push({ date: null });
+    return cells;
+  }, [monthStart, monthEnd]);
+
+  const openModal = (d: Date) => {
+    setSelectedDate(ymd(d));
+    setKind('INCOME');
+    setAmount(0);
+    setCategoryId('');
+    setNotes('');
+    setOpen(true);
+  };
+
+  const createTx = async () => {
+    if (amount <= 0) { alert('金額需大於 0'); return; }
+    const userId = '00000000-0000-0000-0000-000000000001';
+    const occurredAt = new Date(`${selectedDate}T00:00:00`).toISOString();
+    const findAcc = (id: string) => accounts.find(a => a.id === id);
+
+    type BasePayload = { userId: string; kind: Kind; amount: number; occurredAt: string; notes: string | null };
+    type IncomeExpensePayload = BasePayload & { currencyCode: string; accountId: string; categoryId?: string };
+    type TransferPayload = BasePayload & { currencyCode: string; sourceAccountId: string; targetAccountId: string };
+
+    const base: BasePayload = { userId, kind, amount, occurredAt, notes: notes || null };
+    const payload: IncomeExpensePayload | TransferPayload = (kind === 'INCOME' || kind === 'EXPENSE')
+      ? (() => {
+          const acc = findAcc(accountId);
+          if (!acc) { alert('請選擇帳戶'); throw new Error('missing account'); }
+          return { ...base, accountId, currencyCode: acc.currencyCode, ...(categoryId ? { categoryId } : {}) };
+        })()
+      : (() => {
+          const source = findAcc(sourceAccountId);
+          const target = findAcc(targetAccountId);
+          if (!source || !target) { alert('請選擇來源與目標帳戶'); throw new Error('missing source/target'); }
+          return { ...base, sourceAccountId, targetAccountId, currencyCode: source.currencyCode };
+        })();
+
+    const res = await fetch(API_TX, { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify(payload) });
+    if (!res.ok) {
+      let message = await res.text();
+      try { const j: { message?: string } = JSON.parse(message); if (j.message) message = j.message; } catch { void 0; }
+      alert(`建立交易失敗：${message}`);
+      return;
+    }
+    setOpen(false);
+    // reload month
+    try {
+      const res2 = await fetch(`${API_TX}?from=${encodeURIComponent(fromISO)}&to=${encodeURIComponent(toISO)}&page=0&size=500`);
+      const data = await res2.json();
+      const list: TxItem[] = (data.content ?? data) as TxItem[];
+      setItems(list);
+    } catch {}
+  };
+
+  return (
+    <div>
+      <h1>交易月曆</h1>
+      <div>
+        <button onClick={() => setCursor(addMonths(cursor, -1))}>{'<<'}</button>
+        <strong style={{ margin: '0 8px' }}>{cursor.getFullYear()} - {cursor.getMonth() + 1}</strong>
+        <button onClick={() => setCursor(addMonths(cursor, 1))}>{'>>'}</button>
+      </div>
+      {loading && <p>載入中...</p>}
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(7, 1fr)', gap: '6px', marginTop: '10px' }}>
+        {['日','一','二','三','四','五','六'].map((w) => (
+          <div key={w} style={{ textAlign: 'center', fontWeight: 700 }}>{w}</div>
+        ))}
+        {daysGrid.map((cell, idx) => {
+          if (!cell.date) return <div key={idx} />;
+          const label = ymd(cell.date);
+          const count = countsByDay.get(label) ?? 0;
+          return (
+            <div key={idx} style={{ border: '1px solid #ddd', padding: '6px', minHeight: '60px', cursor: 'pointer' }} onClick={() => openModal(cell.date!)}>
+              <div style={{ fontSize: '12px', opacity: 0.8 }}>{cell.date.getDate()}</div>
+              <div style={{ fontSize: '12px' }}>{count > 0 ? `${count} 筆` : ''}</div>
+            </div>
+          );
+        })}
+      </div>
+
+      {open && (
+        <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.3)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+          <div style={{ background: '#fff', padding: 16, minWidth: 320 }}>
+            <h3>建立交易（{selectedDate}）</h3>
+            <div>
+              <label>類型：</label>
+              <label><input type="radio" name="kind" value="INCOME" checked={kind==='INCOME'} onChange={() => setKind('INCOME')} /> 收入</label>
+              <label><input type="radio" name="kind" value="EXPENSE" checked={kind==='EXPENSE'} onChange={() => setKind('EXPENSE')} /> 支出</label>
+              <label><input type="radio" name="kind" value="TRANSFER" checked={kind==='TRANSFER'} onChange={() => setKind('TRANSFER')} /> 轉帳</label>
+            </div>
+            <div>
+              <label>金額：</label>
+              <input type="number" value={amount} onChange={(e) => setAmount(parseFloat(e.target.value || '0'))} step="0.01" min="0.01" />
+            </div>
+            {kind !== 'TRANSFER' ? (
+              <div>
+                <label>帳戶：</label>
+                <select value={accountId} onChange={(e) => setAccountId(e.target.value)}>
+                  {accounts.map(a => <option key={a.id} value={a.id}>{a.name} ({a.currencyCode})</option>)}
+                </select>
+              </div>
+            ) : (
+              <>
+                <div>
+                  <label>來源：</label>
+                  <select value={sourceAccountId} onChange={(e) => setSourceAccountId(e.target.value)}>
+                    {accounts.map(a => <option key={a.id} value={a.id}>{a.name} ({a.currencyCode})</option>)}
+                  </select>
+                </div>
+                <div>
+                  <label>目標：</label>
+                  <select value={targetAccountId} onChange={(e) => setTargetAccountId(e.target.value)}>
+                    {accounts.map(a => <option key={a.id} value={a.id}>{a.name} ({a.currencyCode})</option>)}
+                  </select>
+                </div>
+              </>
+            )}
+            {kind !== 'TRANSFER' && (
+              <div>
+                <label>分類（可選）：</label>
+                <select value={categoryId} onChange={(e) => setCategoryId(e.target.value)}>
+                  <option value="">-- 無 --</option>
+                  {/* 展平分類略，和 TransactionsPage 一致可後續抽共用 */}
+                </select>
+              </div>
+            )}
+            <div>
+              <label>備註：</label>
+              <input value={notes} onChange={(e) => setNotes(e.target.value)} />
+            </div>
+            <div style={{ marginTop: 8 }}>
+              <button onClick={createTx}>建立</button>
+              <button onClick={() => setOpen(false)} style={{ marginLeft: 8 }}>取消</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/pages/TransactionsCalendarPage.tsx
+++ b/frontend/src/pages/TransactionsCalendarPage.tsx
@@ -283,10 +283,10 @@ export function TransactionsCalendarPage() {
                   {itemsOfSelectedDay.map((it) => {
                     const color = it.kind === 'INCOME' ? '#138a36' : it.kind === 'EXPENSE' ? '#c62828' : '#1565c0';
                     const sign = it.kind === 'INCOME' ? '+' : it.kind === 'EXPENSE' ? '-' : '';
-                    const src = it.kind === 'TRANSFER' && it.sourceAccountId ? accountMap.get(it.sourceAccountId)?.name : undefined;
-                    const dst = it.kind === 'TRANSFER' && it.targetAccountId ? accountMap.get(it.targetAccountId)?.name : undefined;
-                    const acc = it.kind !== 'TRANSFER' && it.accountId ? accountMap.get(it.accountId)?.name : undefined;
-                    const cat = it.categoryId ? categoryMap.get(it.categoryId) : '';
+                    const src = it.kind === 'TRANSFER' && it.sourceAccountId ? (accountMap.get(it.sourceAccountId)?.name ?? (it.sourceAccountId.slice(0,8)+'…')) : undefined;
+                    const dst = it.kind === 'TRANSFER' && it.targetAccountId ? (accountMap.get(it.targetAccountId)?.name ?? (it.targetAccountId.slice(0,8)+'…')) : undefined;
+                    const acc = it.kind !== 'TRANSFER' && it.accountId ? (accountMap.get(it.accountId)?.name ?? (it.accountId.slice(0,8)+'…')) : undefined;
+                    const cat = it.categoryId ? (categoryMap.get(it.categoryId) ?? it.categoryId.slice(0,8)+'…') : '';
                     const userName = '';
                     return (
                       <div key={it.id} style={{ display: 'grid', gridTemplateColumns: '120px 1fr 1fr 1fr 120px 80px', gap: 8, alignItems: 'center', padding: '6px 0', borderBottom: '1px solid #f7f7f7' }}>

--- a/frontend/src/pages/TransactionsCalendarPage.tsx
+++ b/frontend/src/pages/TransactionsCalendarPage.tsx
@@ -28,6 +28,18 @@ function toIsoStart(z: Date) { return new Date(Date.UTC(z.getFullYear(), z.getMo
 function toIsoNextDay(z: Date) { return new Date(Date.UTC(z.getFullYear(), z.getMonth(), z.getDate() + 1, 0, 0, 0)).toISOString(); }
 function ymd(d: Date) { return `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`; }
 
+function flattenCategories(nodes: CategoryNode[]): { id: string; name: string; level: number }[] {
+  const out: { id: string; name: string; level: number }[] = [];
+  const walk = (arr: CategoryNode[], level: number) => {
+    for (const n of arr) {
+      out.push({ id: n.id, name: n.name, level });
+      if (n.children && n.children.length) walk(n.children, level + 1);
+    }
+  };
+  walk(nodes, 0);
+  return out;
+}
+
 export function TransactionsCalendarPage() {
   const [cursor, setCursor] = useState<Date>(startOfMonth(new Date()));
   const [items, setItems] = useState<TxItem[]>([]);
@@ -125,6 +137,8 @@ export function TransactionsCalendarPage() {
     walk(categories);
     return m;
   }, [categories]);
+
+  const flatCategoryOptions = useMemo(() => flattenCategories(categories), [categories]);
 
   const itemsOfSelectedDay = useMemo(() => {
     if (!selectedDate) return [] as TxItem[];
@@ -324,7 +338,9 @@ export function TransactionsCalendarPage() {
                 <label>分類（可選）：</label>
                 <select value={categoryId} onChange={(e) => setCategoryId(e.target.value)}>
                   <option value="">-- 無 --</option>
-                  {/* 展平分類略，和 TransactionsPage 一致可後續抽共用 */}
+                  {flatCategoryOptions.map(c => (
+                    <option key={c.id} value={c.id}>{`${'--'.repeat(c.level)} ${c.name}`}</option>
+                  ))}
                 </select>
               </div>
             )}

--- a/frontend/src/pages/TransactionsCalendarPage.tsx
+++ b/frontend/src/pages/TransactionsCalendarPage.tsx
@@ -272,12 +272,13 @@ export function TransactionsCalendarPage() {
                 <div style={{ fontSize: 12, color: '#777' }}>當日尚無交易</div>
               ) : (
                 <div>
-                  <div style={{ display: 'grid', gridTemplateColumns: '120px 1fr 1fr 1fr 120px', gap: 8, fontSize: 12, fontWeight: 600, color: '#333', paddingBottom: 6, borderBottom: '1px solid #f2f2f2' }}>
+                  <div style={{ display: 'grid', gridTemplateColumns: '120px 1fr 1fr 1fr 120px 80px', gap: 8, fontSize: 12, fontWeight: 600, color: '#333', paddingBottom: 6, borderBottom: '1px solid #f2f2f2' }}>
                     <div>金額</div>
                     <div>類別</div>
                     <div>帳戶/來源→目標</div>
                     <div>備註</div>
                     <div>使用者</div>
+                    <div>操作</div>
                   </div>
                   {itemsOfSelectedDay.map((it) => {
                     const color = it.kind === 'INCOME' ? '#138a36' : it.kind === 'EXPENSE' ? '#c62828' : '#1565c0';
@@ -288,13 +289,13 @@ export function TransactionsCalendarPage() {
                     const cat = it.categoryId ? categoryMap.get(it.categoryId) : '';
                     const userName = '';
                     return (
-                      <div key={it.id} style={{ display: 'grid', gridTemplateColumns: '120px 1fr 1fr 1fr 120px', gap: 8, alignItems: 'center', padding: '6px 0', borderBottom: '1px solid #f7f7f7' }}>
+                      <div key={it.id} style={{ display: 'grid', gridTemplateColumns: '120px 1fr 1fr 1fr 120px 80px', gap: 8, alignItems: 'center', padding: '6px 0', borderBottom: '1px solid #f7f7f7' }}>
                         <div style={{ color, fontWeight: 700 }}>{sign}{it.amount.toLocaleString()}</div>
                         <div>{cat || '—'}</div>
                         <div>{it.kind === 'TRANSFER' ? (<>{src ?? '來源?'} → {dst ?? '目標?'}</>) : (acc ?? '帳戶?')}</div>
                         <div style={{ color: '#555', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{it.notes || '—'}</div>
-                        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-                          <span>{userName}</span>
+                        <div>{userName}</div>
+                        <div>
                           <button onClick={() => deleteTx(it.id)} style={{ padding: '2px 6px', border: '1px solid #d32f2f', color: '#d32f2f', background: '#fff', borderRadius: 4, cursor: 'pointer' }}>刪除</button>
                         </div>
                       </div>

--- a/frontend/src/pages/TransactionsCalendarPage.tsx
+++ b/frontend/src/pages/TransactionsCalendarPage.tsx
@@ -264,7 +264,7 @@ export function TransactionsCalendarPage() {
 
       {open && (
         <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.3)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
-          <div style={{ background: '#fff', padding: 16, minWidth: 320 }}>
+          <div style={{ background: '#fff', padding: 16, minWidth: 320, color: '#222' }}>
             <h3>建立交易（{selectedDate}）</h3>
             {/* Existing items for the day (summary list) */}
             <div style={{ maxHeight: 200, overflow: 'auto', marginBottom: 8, border: '1px solid #eee', padding: 8 }}>
@@ -272,7 +272,7 @@ export function TransactionsCalendarPage() {
                 <div style={{ fontSize: 12, color: '#777' }}>當日尚無交易</div>
               ) : (
                 <div>
-                  <div style={{ display: 'grid', gridTemplateColumns: '120px 1fr 1fr 1fr 120px 80px', gap: 8, fontSize: 12, fontWeight: 600, color: '#333', paddingBottom: 6, borderBottom: '1px solid #f2f2f2' }}>
+                  <div style={{ display: 'grid', gridTemplateColumns: '120px 1fr 1fr 1fr 120px 80px', gap: 8, fontSize: 12, fontWeight: 600, color: '#222', paddingBottom: 6, borderBottom: '1px solid #f2f2f2' }}>
                     <div>金額</div>
                     <div>類別</div>
                     <div>帳戶/來源→目標</div>
@@ -291,10 +291,10 @@ export function TransactionsCalendarPage() {
                     return (
                       <div key={it.id} style={{ display: 'grid', gridTemplateColumns: '120px 1fr 1fr 1fr 120px 80px', gap: 8, alignItems: 'center', padding: '6px 0', borderBottom: '1px solid #f7f7f7' }}>
                         <div style={{ color, fontWeight: 700 }}>{sign}{it.amount.toLocaleString()}</div>
-                        <div>{cat || '—'}</div>
-                        <div>{it.kind === 'TRANSFER' ? (<>{src ?? '來源?'} → {dst ?? '目標?'}</>) : (acc ?? '帳戶?')}</div>
-                        <div style={{ color: '#555', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{it.notes || '—'}</div>
-                        <div>{userName}</div>
+                        <div style={{ color: '#222' }}>{cat || '—'}</div>
+                        <div style={{ color: '#222' }}>{it.kind === 'TRANSFER' ? (<>{src ?? '來源?'} → {dst ?? '目標?'}</>) : (acc ?? '帳戶?')}</div>
+                        <div style={{ color: '#444', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>{it.notes || '—'}</div>
+                        <div style={{ color: '#222' }}>{userName}</div>
                         <div>
                           <button onClick={() => deleteTx(it.id)} style={{ padding: '2px 6px', border: '1px solid #d32f2f', color: '#d32f2f', background: '#fff', borderRadius: 4, cursor: 'pointer' }}>刪除</button>
                         </div>


### PR DESCRIPTION
 - 內容
      - 摘要
      - 後端 GET /api/transactions（期間查詢、分頁）
      - 後端 DELETE /api/transactions/{id}（回沖餘額後刪除）
      - 月曆頁：每日筆數統計、點日開 Modal 建立交易、顯示明細（金額/類別/帳戶/備註/使用者/操作）、刪除按鈕
      - UI 可讀性：對比色、類型分段按鈕（收入綠/支出紅/轉帳藍）
      - 文件：docs/api/transactions.md 增補 GET/DELETE；README 連結更新
  - 端點
      - GET `/api/transactions?from=&to=&page=&size=`
      - DELETE `/api/transactions/{id}`
  - 驗證重點
      - 月曆載入當月資料，每日筆數正確
      - Modal 明細顯示類別、帳戶/來源→目標、備註、使用者
      - 建立/刪除交易後，列表與每日筆數同步更新，帳戶餘額回沖正確
  - 清單
      - [ ] 前端 lint/build 綠
      - [ ] 後端 test/docker build 綠
      - [ ] GET 回傳 Page 結構正確
      - [ ] DELETE 成功與錯誤（404）格式正確
  - 文件
      - docs/api/transactions.md：新增 GET/DELETE 章節
      - README.md：12.1 改為建立/查詢/刪除總覽

  Compare 連結

  - https://github.com/WIse4466/pocketfolio/compare/main...feature/transactions-list-and-calendar