### PR TITLE
feat(frontend): CC 專屬欄位顯示與帳戶編輯；交易頁/月曆 UX 調整；數字輸入體驗修正

### DIFF
--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -67,13 +67,21 @@ export function AccountPage() {
 
     const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
         const { name, value, type } = e.target;
-        let parsedValue: string | number | boolean = value;
+        let parsedValue: string | number | boolean | undefined = value;
 
         if (type === 'number') {
-            parsedValue = parseFloat(value);
-            if (isNaN(parsedValue)) parsedValue = 0; // Handle empty or invalid number input
+            const n = parseFloat(value);
+            parsedValue = isNaN(n) ? 0 : n;
         } else if (type === 'checkbox') {
             parsedValue = (e.target as HTMLInputElement).checked;
+        } else {
+            // select inputs: coerce specific fields to numbers
+            if (name === 'closingDay' || name === 'dueDay') {
+                parsedValue = value === '' ? undefined : parseInt(value, 10);
+            }
+            if (name === 'dueMonthOffset') {
+                parsedValue = parseInt(value, 10) as 0 | 1 | 2;
+            }
         }
 
         // When switching away from CREDIT_CARD, clear CC-specific fields
@@ -218,12 +226,13 @@ export function AccountPage() {
                 {formData.type === 'CREDIT_CARD' && (
                     <>
                         <div>
-                            <label htmlFor="closingDay">結帳日 (1–31)：</label>
+                            <label htmlFor="closingDay">結帳日：</label>
                             <select id="closingDay" name="closingDay" value={formData.closingDay ?? ''} onChange={handleChange}>
                                 <option value="">-- 請選擇 --</option>
-                                {Array.from({ length: 31 }, (_, i) => i + 1).map(d => (
+                                {Array.from({ length: 28 }, (_, i) => i + 1).map(d => (
                                     <option key={d} value={d}>{d}</option>
                                 ))}
+                                <option value={31}>月末</option>
                             </select>
                         </div>
                         <div>
@@ -237,10 +246,11 @@ export function AccountPage() {
                             </span>
                             <span>
                                 <select id="dueDay" name="dueDay" value={formData.dueDay ?? ''} onChange={handleChange}>
-                                    <option value="">-- 日（1–31）--</option>
-                                    {Array.from({ length: 31 }, (_, i) => i + 1).map(d => (
+                                    <option value="">-- 日（1–28/月末）--</option>
+                                    {Array.from({ length: 28 }, (_, i) => i + 1).map(d => (
                                         <option key={d} value={d}>{d}</option>
                                     ))}
+                                    <option value={31}>月末</option>
                                 </select>
                             </span>
                         </div>

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -39,6 +39,10 @@ export function AccountPage() {
         dueDay: undefined as number | undefined,
         // UI-only: 繳款月份偏移（0=本月,1=下月,2=下下月）。目前後端尚未保存此欄位。
         dueMonthOffset: 1 as 0 | 1 | 2, // 預設下月
+        // UI-only: 繳款日假日調整策略（NONE=不調整, ADVANCE=提前, POSTPONE=順延）
+        dueHolidayPolicy: 'NONE' as 'NONE' | 'ADVANCE' | 'POSTPONE',
+        // UI-only: 是否啟用自動繳款（若啟用才會送 autopayAccount）
+        autopayEnabled: false,
         autopayAccountId: '' as string | undefined,
         notes: '',
     });
@@ -82,6 +86,8 @@ export function AccountPage() {
                     closingDay: undefined,
                     dueDay: undefined,
                     dueMonthOffset: 1,
+                    dueHolidayPolicy: 'NONE' as const,
+                    autopayEnabled: false,
                     autopayAccountId: undefined,
                 } : {})
             }));
@@ -111,7 +117,8 @@ export function AccountPage() {
             archived: formData.archived,
             closingDay: formData.closingDay || null, // Send null if undefined
             dueDay: formData.dueDay || null,         // Send null if undefined
-            autopayAccount: formData.autopayAccountId ? { id: formData.autopayAccountId } : null, // Only send ID
+            // 僅在啟用自動繳款且選擇帳戶時才送 autopayAccount；否則送 null
+            autopayAccount: (formData.autopayEnabled && formData.autopayAccountId) ? { id: formData.autopayAccountId } : null,
             notes: formData.notes || null,
         };
 
@@ -238,8 +245,21 @@ export function AccountPage() {
                             </span>
                         </div>
                         <div>
+                            <label htmlFor="dueHolidayPolicy">繳款日假日調整：</label>
+                            <select id="dueHolidayPolicy" name="dueHolidayPolicy" value={formData.dueHolidayPolicy} onChange={handleChange}>
+                                <option value="NONE">不調整</option>
+                                <option value="ADVANCE">提前至最近工作日</option>
+                                <option value="POSTPONE">順延至下一工作日</option>
+                            </select>
+                            <span style={{ marginLeft: 8, fontSize: 12, color: '#666' }}>(目前僅前端設定，後端未保存)</span>
+                        </div>
+                        <div>
+                            <label htmlFor="autopayEnabled">啟用自動繳款：</label>
+                            <input id="autopayEnabled" name="autopayEnabled" type="checkbox" checked={formData.autopayEnabled} onChange={handleChange} />
+                        </div>
+                        <div>
                             <label htmlFor="autopayAccountId">自動繳款帳戶：</label>
-                            <select id="autopayAccountId" name="autopayAccountId" value={formData.autopayAccountId || ''} onChange={handleChange}>
+                            <select id="autopayAccountId" name="autopayAccountId" value={formData.autopayAccountId || ''} onChange={handleChange} disabled={!formData.autopayEnabled}>
                                 <option value="">-- 無 --</option>
                                 {autopayOptions.map(acc => (
                                     <option key={acc.id} value={acc.id}>{acc.name} ({acc.type})</option>

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -70,6 +70,21 @@ export function AccountPage() {
             parsedValue = (e.target as HTMLInputElement).checked;
         }
 
+        // When switching away from CREDIT_CARD, clear CC-specific fields
+        if (name === 'type') {
+            const nextType = parsedValue as AccountType;
+            setFormData(prev => ({
+                ...prev,
+                type: nextType,
+                ...(nextType !== 'CREDIT_CARD' ? {
+                    closingDay: undefined,
+                    dueDay: undefined,
+                    autopayAccountId: undefined,
+                } : {})
+            }));
+            return;
+        }
+
         setFormData(prev => ({
             ...prev,
             [name]: parsedValue
@@ -190,23 +205,27 @@ export function AccountPage() {
                     <label htmlFor="archived">已封存：</label>
                     <input id="archived" name="archived" type="checkbox" checked={formData.archived} onChange={handleChange} />
                 </div>
-                <div>
-                    <label htmlFor="closingDay">結帳日 (信用卡)：</label>
-                    <input id="closingDay" name="closingDay" type="number" value={formData.closingDay || ''} onChange={handleChange} min="1" max="31" />
-                </div>
-                <div>
-                    <label htmlFor="dueDay">繳款日 (信用卡)：</label>
-                    <input id="dueDay" name="dueDay" type="number" value={formData.dueDay || ''} onChange={handleChange} min="1" max="31" />
-                </div>
-                <div>
-                    <label htmlFor="autopayAccountId">自動繳款帳戶：</label>
-                    <select id="autopayAccountId" name="autopayAccountId" value={formData.autopayAccountId || ''} onChange={handleChange}>
-                        <option value="">-- 無 --</option>
-                        {autopayOptions.map(acc => (
-                            <option key={acc.id} value={acc.id}>{acc.name} ({acc.type})</option>
-                        ))}
-                    </select>
-                </div>
+                {formData.type === 'CREDIT_CARD' && (
+                    <>
+                        <div>
+                            <label htmlFor="closingDay">結帳日 (信用卡)：</label>
+                            <input id="closingDay" name="closingDay" type="number" value={formData.closingDay || ''} onChange={handleChange} min="1" max="31" />
+                        </div>
+                        <div>
+                            <label htmlFor="dueDay">繳款日 (信用卡)：</label>
+                            <input id="dueDay" name="dueDay" type="number" value={formData.dueDay || ''} onChange={handleChange} min="1" max="31" />
+                        </div>
+                        <div>
+                            <label htmlFor="autopayAccountId">自動繳款帳戶：</label>
+                            <select id="autopayAccountId" name="autopayAccountId" value={formData.autopayAccountId || ''} onChange={handleChange}>
+                                <option value="">-- 無 --</option>
+                                {autopayOptions.map(acc => (
+                                    <option key={acc.id} value={acc.id}>{acc.name} ({acc.type})</option>
+                                ))}
+                            </select>
+                        </div>
+                    </>
+                )}
                 <div>
                     <label htmlFor="notes">備註：</label>
                     <textarea id="notes" name="notes" value={formData.notes} onChange={handleChange} maxLength={500} />

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -33,7 +33,8 @@ export function AccountPage() {
         name: '',
         type: 'CASH' as AccountType, // Default to CASH
         currencyCode: 'TWD',
-        initialBalance: 0,
+        // 以字串狀態綁定，避免輸入時被強制成 0
+        initialBalanceInput: '' as string,
         includeInNetWorth: true,
         archived: false,
         closingDay: undefined as number | undefined,
@@ -68,11 +69,16 @@ export function AccountPage() {
 
     const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
         const { name, value, type } = e.target;
-        let parsedValue: string | number | boolean | undefined = value;
+        let parsedValue: any = value;
 
         if (type === 'number') {
-            const n = parseFloat(value);
-            parsedValue = isNaN(n) ? 0 : n;
+            // 對於金額等可自由輸入，保留字串，避免強制 0
+            if (name === 'initialBalanceInput') {
+                parsedValue = value;
+            } else {
+                const n = parseFloat(value);
+                parsedValue = isNaN(n) ? undefined : n;
+            }
         } else if (type === 'checkbox') {
             parsedValue = (e.target as HTMLInputElement).checked;
         } else {
@@ -115,13 +121,14 @@ export function AccountPage() {
         // For now, hardcode userId. In a real app, this would come from auth context.
         const userId = '00000000-0000-0000-0000-000000000001'; 
 
+        const initialBalance = parseFloat(formData.initialBalanceInput || '0');
         const accountPayload = {
             userId,
             name: formData.name,
             type: formData.type,
             currencyCode: formData.currencyCode,
-            initialBalance: formData.initialBalance,
-            currentBalance: formData.initialBalance, // Current balance starts as initial balance
+            initialBalance: isNaN(initialBalance) ? 0 : initialBalance,
+            currentBalance: isNaN(initialBalance) ? 0 : initialBalance, // Current balance starts as initial balance
             includeInNetWorth: formData.includeInNetWorth,
             archived: formData.archived,
             closingDay: formData.type === 'CREDIT_CARD' ? (formData.closingDay || null) : null,
@@ -151,7 +158,7 @@ export function AccountPage() {
                 name: '',
                 type: 'CASH',
                 currencyCode: 'TWD',
-                initialBalance: 0,
+                initialBalanceInput: '',
                 includeInNetWorth: true,
                 archived: false,
                 closingDay: undefined,
@@ -202,7 +209,7 @@ export function AccountPage() {
             name: acc.name,
             type: acc.type as AccountType,
             currencyCode: acc.currencyCode,
-            initialBalance: acc.initialBalance ?? 0,
+            initialBalanceInput: (acc.initialBalance ?? 0).toString(),
             includeInNetWorth: acc.includeInNetWorth,
             archived: acc.archived,
             closingDay: acc.closingDay ?? undefined as any,
@@ -221,7 +228,7 @@ export function AccountPage() {
             name: '',
             type: 'CASH',
             currencyCode: 'TWD',
-            initialBalance: 0,
+            initialBalanceInput: '',
             includeInNetWorth: true,
             archived: false,
             closingDay: undefined,
@@ -256,8 +263,8 @@ export function AccountPage() {
                     <input id="currencyCode" name="currencyCode" type="text" value={formData.currencyCode} onChange={handleChange} required maxLength={3} />
                 </div>
                 <div>
-                    <label htmlFor="initialBalance">初始餘額：</label>
-                    <input id="initialBalance" name="initialBalance" type="number" value={formData.initialBalance} onChange={handleChange} required step="0.01" />
+                    <label htmlFor="initialBalanceInput">初始餘額：</label>
+                    <input id="initialBalanceInput" name="initialBalanceInput" type="number" value={formData.initialBalanceInput} onChange={handleChange} step="0.01" />
                 </div>
                 <div>
                     <label htmlFor="includeInNetWorth">計入淨資產：</label>

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -37,6 +37,8 @@ export function AccountPage() {
         archived: false,
         closingDay: undefined as number | undefined,
         dueDay: undefined as number | undefined,
+        // UI-only: 繳款月份偏移（0=本月,1=下月,2=下下月）。目前後端尚未保存此欄位。
+        dueMonthOffset: 1 as 0 | 1 | 2, // 預設下月
         autopayAccountId: '' as string | undefined,
         notes: '',
     });
@@ -79,6 +81,7 @@ export function AccountPage() {
                 ...(nextType !== 'CREDIT_CARD' ? {
                     closingDay: undefined,
                     dueDay: undefined,
+                    dueMonthOffset: 1,
                     autopayAccountId: undefined,
                 } : {})
             }));
@@ -208,12 +211,31 @@ export function AccountPage() {
                 {formData.type === 'CREDIT_CARD' && (
                     <>
                         <div>
-                            <label htmlFor="closingDay">結帳日 (信用卡)：</label>
-                            <input id="closingDay" name="closingDay" type="number" value={formData.closingDay || ''} onChange={handleChange} min="1" max="31" />
+                            <label htmlFor="closingDay">結帳日 (1–31)：</label>
+                            <select id="closingDay" name="closingDay" value={formData.closingDay ?? ''} onChange={handleChange}>
+                                <option value="">-- 請選擇 --</option>
+                                {Array.from({ length: 31 }, (_, i) => i + 1).map(d => (
+                                    <option key={d} value={d}>{d}</option>
+                                ))}
+                            </select>
                         </div>
                         <div>
-                            <label htmlFor="dueDay">繳款日 (信用卡)：</label>
-                            <input id="dueDay" name="dueDay" type="number" value={formData.dueDay || ''} onChange={handleChange} min="1" max="31" />
+                            <label>繳款日：</label>
+                            <span style={{ marginRight: 8 }}>
+                                <select id="dueMonthOffset" name="dueMonthOffset" value={formData.dueMonthOffset} onChange={handleChange}>
+                                    <option value={0}>本月</option>
+                                    <option value={1}>下月</option>
+                                    <option value={2}>下下月</option>
+                                </select>
+                            </span>
+                            <span>
+                                <select id="dueDay" name="dueDay" value={formData.dueDay ?? ''} onChange={handleChange}>
+                                    <option value="">-- 日（1–31）--</option>
+                                    {Array.from({ length: 31 }, (_, i) => i + 1).map(d => (
+                                        <option key={d} value={d}>{d}</option>
+                                    ))}
+                                </select>
+                            </span>
                         </div>
                         <div>
                             <label htmlFor="autopayAccountId">自動繳款帳戶：</label>

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -69,7 +69,7 @@ export function AccountPage() {
 
     const handleChange = (e: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
         const { name, value, type } = e.target;
-        let parsedValue: any = value;
+        let parsedValue: string | number | boolean | undefined = value;
 
         if (type === 'number') {
             // 對於金額等可自由輸入，保留字串，避免強制 0
@@ -212,14 +212,14 @@ export function AccountPage() {
             initialBalanceInput: (acc.initialBalance ?? 0).toString(),
             includeInNetWorth: acc.includeInNetWorth,
             archived: acc.archived,
-            closingDay: acc.closingDay ?? undefined as any,
-            dueDay: acc.dueDay ?? undefined as any,
+            closingDay: acc.closingDay ?? undefined,
+            dueDay: acc.dueDay ?? undefined,
             dueMonthOffset: 1, // default; backend not storing yet
             dueHolidayPolicy: 'NONE', // default; backend not storing yet
             autopayEnabled: Boolean(acc.autopayAccount?.id),
             autopayAccountId: acc.autopayAccount?.id,
             notes: acc.notes ?? '',
-        } as any);
+        });
     };
 
     const cancelEdit = () => {

--- a/frontend/src/pages/TransactionsCalendarPage.tsx
+++ b/frontend/src/pages/TransactionsCalendarPage.tsx
@@ -51,7 +51,7 @@ export function TransactionsCalendarPage() {
 
   // Form state (lightweight, similar to TransactionsPage)
   const [kind, setKind] = useState<Kind>('INCOME');
-  const [amount, setAmount] = useState<number>(0);
+  const [amount, setAmount] = useState<string>('');
   const [accountId, setAccountId] = useState<string>('');
   const [sourceAccountId, setSourceAccountId] = useState<string>('');
   const [targetAccountId, setTargetAccountId] = useState<string>('');
@@ -168,7 +168,8 @@ export function TransactionsCalendarPage() {
   };
 
   const createTx = async () => {
-    if (amount <= 0) { alert('金額需大於 0'); return; }
+    const amountNum = parseFloat(amount);
+    if (!amount || isNaN(amountNum) || amountNum <= 0) { alert('金額需大於 0'); return; }
     const userId = '00000000-0000-0000-0000-000000000001';
     const occurredAt = new Date(`${selectedDate}T00:00:00`).toISOString();
     const findAcc = (id: string) => accounts.find(a => a.id === id);
@@ -177,7 +178,7 @@ export function TransactionsCalendarPage() {
     type IncomeExpensePayload = BasePayload & { currencyCode: string; accountId: string; categoryId?: string };
     type TransferPayload = BasePayload & { currencyCode: string; sourceAccountId: string; targetAccountId: string };
 
-    const base: BasePayload = { userId, kind, amount, occurredAt, notes: notes || null };
+    const base: BasePayload = { userId, kind, amount: amountNum, occurredAt, notes: notes || null };
     const payload: IncomeExpensePayload | TransferPayload = (kind === 'INCOME' || kind === 'EXPENSE')
       ? (() => {
           const acc = findAcc(accountId);
@@ -348,7 +349,7 @@ export function TransactionsCalendarPage() {
             </div>
             <div>
               <label>金額：</label>
-              <input type="number" value={amount} onChange={(e) => setAmount(parseFloat(e.target.value || '0'))} step="0.01" min="0.01" />
+              <input type="number" value={amount} onChange={(e) => setAmount(e.target.value)} step="0.01" min="0.01" />
             </div>
             {kind !== 'TRANSFER' ? (
               <div>

--- a/frontend/src/pages/TransactionsCalendarPage.tsx
+++ b/frontend/src/pages/TransactionsCalendarPage.tsx
@@ -160,7 +160,7 @@ export function TransactionsCalendarPage() {
 
   const openModal = (d: Date) => {
     setSelectedDate(ymd(d));
-    setKind('INCOME');
+    setKind('EXPENSE');
     setAmount('');
     setCategoryId('');
     setNotes('');
@@ -326,6 +326,7 @@ export function TransactionsCalendarPage() {
                     type="button"
                     role="tab"
                     aria-selected={kind === opt.key}
+                    autoFocus={opt.key === 'EXPENSE'}
                     onClick={() => setKind(opt.key)}
                     title={opt.label}
                     style={{

--- a/frontend/src/pages/TransactionsCalendarPage.tsx
+++ b/frontend/src/pages/TransactionsCalendarPage.tsx
@@ -317,8 +317,8 @@ export function TransactionsCalendarPage() {
               <div style={{ marginBottom: 6, fontSize: 12, color: '#555' }}>交易類型：</div>
               <div role="tablist" aria-label="交易類型" style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
                 {([
-                  { key: 'INCOME' as Kind, label: '收入', symbol: '+', color: '#138a36' },
                   { key: 'EXPENSE' as Kind, label: '支出', symbol: '−', color: '#c62828' },
+                  { key: 'INCOME' as Kind, label: '收入', symbol: '+', color: '#138a36' },
                   { key: 'TRANSFER' as Kind, label: '轉帳', symbol: '↔', color: '#1565c0' },
                 ]).map(opt => (
                   <button

--- a/frontend/src/pages/TransactionsCalendarPage.tsx
+++ b/frontend/src/pages/TransactionsCalendarPage.tsx
@@ -161,7 +161,7 @@ export function TransactionsCalendarPage() {
   const openModal = (d: Date) => {
     setSelectedDate(ymd(d));
     setKind('INCOME');
-    setAmount(0);
+    setAmount('');
     setCategoryId('');
     setNotes('');
     setOpen(true);

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -43,7 +43,7 @@ function flattenCategories(categories: CategoryNode[]): { id: string; name: stri
 }
 
 export function TransactionsPage() {
-  const [kind, setKind] = useState<Kind>('INCOME');
+  const [kind, setKind] = useState<Kind>('EXPENSE');
   const [date, setDate] = useState<string>(todayStr());
   const [amount, setAmount] = useState<string>('');
   const [accountId, setAccountId] = useState<string>('');
@@ -191,8 +191,8 @@ export function TransactionsPage() {
         </div>
         <div>
           <label>類型：</label>
+          <label><input type="radio" name="kind" value="EXPENSE" checked={kind==='EXPENSE'} onChange={() => setKind('EXPENSE')} autoFocus /> 支出</label>
           <label><input type="radio" name="kind" value="INCOME" checked={kind==='INCOME'} onChange={() => setKind('INCOME')} /> 收入</label>
-          <label><input type="radio" name="kind" value="EXPENSE" checked={kind==='EXPENSE'} onChange={() => setKind('EXPENSE')} /> 支出</label>
           <label><input type="radio" name="kind" value="TRANSFER" checked={kind==='TRANSFER'} onChange={() => setKind('TRANSFER')} /> 轉帳</label>
         </div>
         <div>

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react';
-import type { ChangeEvent, FormEvent } from 'react';
+import type { FormEvent } from 'react';
 
 const API_TX = 'http://localhost:8080/api/transactions';
 const API_ACCOUNTS = 'http://localhost:8080/api/accounts';

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -45,7 +45,7 @@ function flattenCategories(categories: CategoryNode[]): { id: string; name: stri
 export function TransactionsPage() {
   const [kind, setKind] = useState<Kind>('INCOME');
   const [date, setDate] = useState<string>(todayStr());
-  const [amount, setAmount] = useState<number>(0);
+  const [amount, setAmount] = useState<string>('');
   const [accountId, setAccountId] = useState<string>('');
   const [sourceAccountId, setSourceAccountId] = useState<string>('');
   const [targetAccountId, setTargetAccountId] = useState<string>('');
@@ -85,7 +85,8 @@ export function TransactionsPage() {
 
   const onSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    if (amount <= 0) {
+    const amountNum = parseFloat(amount);
+    if (!amount || isNaN(amountNum) || amountNum <= 0) {
       alert('金額需大於 0');
       return;
     }
@@ -115,7 +116,7 @@ export function TransactionsPage() {
       targetAccountId: string;
     };
 
-    const base: BasePayload = { userId, kind, amount, occurredAt, notes: notes || null };
+    const base: BasePayload = { userId, kind, amount: amountNum, occurredAt, notes: notes || null };
 
     const payload: IncomeExpensePayload | TransferPayload = (kind === 'INCOME' || kind === 'EXPENSE')
       ? (() => {
@@ -171,7 +172,7 @@ export function TransactionsPage() {
         } catch { void 0; }
         throw new Error(message);
       }
-      setAmount(0);
+      setAmount('');
       setNotes('');
       alert('交易已建立');
     } catch (err) {
@@ -179,9 +180,6 @@ export function TransactionsPage() {
       alert(`建立交易失敗：${err instanceof Error ? err.message : String(err)}`);
     }
   };
-
-  const onNumber = (setter: (n: number) => void) =>
-    (e: ChangeEvent<HTMLInputElement>) => setter(parseFloat(e.target.value || '0'));
 
   return (
     <div>
@@ -199,7 +197,7 @@ export function TransactionsPage() {
         </div>
         <div>
           <label>金額：</label>
-          <input type="number" value={amount} onChange={onNumber(setAmount)} step="0.01" min="0.01" required />
+          <input type="number" value={amount} onChange={(e) => setAmount(e.target.value)} step="0.01" min="0.01" required />
         </div>
 
         {kind !== 'TRANSFER' ? (


### PR DESCRIPTION
Summary

  - 帳戶管理：信用卡專屬欄位 conditional 顯示，新增「編輯」功能
  - 交易頁與月曆：預設類型和按鈕順序調整，數字輸入不再強制顯示 0
  - 僅前端變更，與現有後端相容；不含 DB 遷移

  Changes

  - AccountPage.tsx
      - 僅當 type=CREDIT_CARD 顯示：結帳日、繳款日（月份偏移+日）、繳款日假日調整、自動繳款設定
      - 結帳日/繳款日（日）選項改為「1–28 + 月末（用 31 表示）」
      - 新增「繳款月份偏移」本月/下月/下下月（UI-only，暫不送後端）
      - 新增「繳款日假日調整」：不調整/提前/順延（UI-only，暫不送後端）
      - 新增「啟用自動繳款」開關；僅啟用且選定帳戶才送 autopayAccount，否則送 null
      - 新增「編輯」功能：點列表「編輯」帶入表單，送 PUT /api/accounts/{id}；可「取消編輯」
      - 切換離開 CREDIT_CARD 時，自動清空 CC 專屬欄位避免殘留
      - 自動繳款帳戶下拉：排除信用卡、且排除自己（避免自動繳款自己）
      - 數字輸入體驗：initialBalance 以字串狀態控制，提交時 parse，避免預設 0/無法清空
  - TransactionsPage.tsx
      - 預設類型改為支出（EXPENSE），順序改為「支出、收入、轉帳」，支出單選預設聚焦
      - 金額輸入以字串控制，提交時 parse 並驗證 > 0，避免預設 0 問題
  - TransactionsCalendarPage.tsx
      - 建立交易彈窗：按鈕順序改為「支出、收入、轉帳」
      - 預設類型改為支出（EXPENSE），左側第一顆按鈕自動聚焦
      - 開啟彈窗時金額預設為空字串；提交時 parse 並驗證 > 0

  Behavior

  - 新增信用卡帳戶時，可設定結帳/繳款（含月末/月份偏移/假日調整）與自動繳款；非信用卡類型不顯示這些欄位
  - 編輯帳戶：可更新名稱/類型/幣別等；CC 專屬欄位僅在信用卡時可調整
  - 交易建立（頁面/月曆）：預設為支出，金額欄位可清空、不再自動填 0

  Validation/AC

  - 帳戶管理
      - 切為 CREDIT_CARD 才看得到結帳日/繳款日/假日調整/自動繳款欄位；切回其他類型即隱藏並清空
      - 自動繳款：未勾選時帳戶下拉不可用；勾選且選定帳戶後，送出 payload 含 autopayAccount
      - 編輯：點列表「編輯」→ 表單帶入；送出 PUT 成功、列表更新；「取消編輯」回到新增模式
  - 交易與月曆
      - 預設類型為支出；按鈕順序支出→收入→轉帳；左側按鈕獲得焦點
      - 金額輸入起始為空，提交時才檢核（> 0）

  Compatibility

  - 僅前端變更；後端已欄位（closingDay/dueDay/autopayAccount/notes）維持既有行為
  - UI-only 欄位（dueMonthOffset, dueHolidayPolicy, autopayEnabled）目前不送後端，不影響 API

  Risk & Rollback

  - 風險低；為純前端行為調整與型別/驗證強化
  - 問題時可 revert 此 PR 以回到舊行為

  Next

  - 後端擴充帳戶欄位（Flyway）：due_month_offset、due_holiday_policy、autopay_enabled
  - Account API/Entity/DTO 對應；前端串接讀寫
  - 視需求將編輯模式的「初始餘額」改為唯讀或設計變更規則