### PR TITLE
feat(billing): planned autopay as transactions (PENDING→POSTED), auto-close/autopay, in-place adjustments; calendar shows directly; fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This format follows Keep a Changelog and adheres to Semantic Versioning where pr
 - 後端：`Account` 實體與 `AccountService` 驗證（DUE_MONTH_OFFSET_INVALID、DUE_HOLIDAY_POLICY_INVALID、AUTOPAY_NOT_SUPPORTED、AUTOPAY_ACCOUNT_INVALID、AUTOPAY_CONFLICT）。
 - 前端：帳戶管理頁送出並讀取上述欄位（信用卡時）。
 - Docs：`docs/api/accounts.md`、README 連結。
+ - DB/Flyway V5：新增 `statements` 表；結帳與自動扣款 MVP（手動結帳端點、每日 00:20 自動扣款）。
 
 ## 0.1.1 — 2025-10-01
 ### Added

--- a/backend/src/main/java/com/example/pocketfolio/PocketfolioApplication.java
+++ b/backend/src/main/java/com/example/pocketfolio/PocketfolioApplication.java
@@ -2,8 +2,10 @@ package com.example.pocketfolio;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class PocketfolioApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/example/pocketfolio/controller/AccountController.java
+++ b/backend/src/main/java/com/example/pocketfolio/controller/AccountController.java
@@ -1,5 +1,6 @@
 package com.example.pocketfolio.controller;
 
+import com.example.pocketfolio.dto.AccountDto;
 import com.example.pocketfolio.entity.Account;
 import com.example.pocketfolio.service.AccountService;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/api/accounts")
@@ -17,28 +19,52 @@ public class AccountController {
 
     private final AccountService accountService;
 
+    private AccountDto toDto(Account a) {
+        return AccountDto.builder()
+                .id(a.getId())
+                .userId(a.getUserId())
+                .name(a.getName())
+                .type(a.getType())
+                .currencyCode(a.getCurrencyCode())
+                .initialBalance(a.getInitialBalance())
+                .currentBalance(a.getCurrentBalance())
+                .includeInNetWorth(a.isIncludeInNetWorth())
+                .archived(a.isArchived())
+                .closingDay(a.getClosingDay())
+                .dueDay(a.getDueDay())
+                .autopayAccountId(a.getAutopayAccount() != null ? a.getAutopayAccount().getId() : null)
+                .dueMonthOffset(a.getDueMonthOffset())
+                .dueHolidayPolicy(a.getDueHolidayPolicy())
+                .autopayEnabled(a.isAutopayEnabled())
+                .notes(a.getNotes())
+                .createdAt(a.getCreatedAt())
+                .updatedAt(a.getUpdatedAt())
+                .build();
+    }
+
     @PostMapping
-    public ResponseEntity<Account> createAccount(@RequestBody Account account) {
+    public ResponseEntity<AccountDto> createAccount(@RequestBody Account account) {
         Account createdAccount = accountService.createAccount(account);
-        return new ResponseEntity<>(createdAccount, HttpStatus.CREATED);
+        return new ResponseEntity<>(toDto(createdAccount), HttpStatus.CREATED);
     }
 
     @GetMapping
-    public ResponseEntity<List<Account>> getAllAccounts() {
+    public ResponseEntity<List<AccountDto>> getAllAccounts() {
         List<Account> accounts = accountService.getAllAccounts();
-        return new ResponseEntity<>(accounts, HttpStatus.OK);
+        List<AccountDto> dtos = accounts.stream().map(this::toDto).collect(Collectors.toList());
+        return new ResponseEntity<>(dtos, HttpStatus.OK);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<Account> getAccountById(@PathVariable UUID id) {
+    public ResponseEntity<AccountDto> getAccountById(@PathVariable UUID id) {
         Account account = accountService.getAccountById(id);
-        return new ResponseEntity<>(account, HttpStatus.OK);
+        return new ResponseEntity<>(toDto(account), HttpStatus.OK);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Account> updateAccount(@PathVariable UUID id, @RequestBody Account account) {
+    public ResponseEntity<AccountDto> updateAccount(@PathVariable UUID id, @RequestBody Account account) {
         Account updatedAccount = accountService.updateAccount(id, account);
-        return new ResponseEntity<>(updatedAccount, HttpStatus.OK);
+        return new ResponseEntity<>(toDto(updatedAccount), HttpStatus.OK);
     }
 
     @DeleteMapping("/{id}")

--- a/backend/src/main/java/com/example/pocketfolio/controller/BillingController.java
+++ b/backend/src/main/java/com/example/pocketfolio/controller/BillingController.java
@@ -1,0 +1,41 @@
+package com.example.pocketfolio.controller;
+
+import com.example.pocketfolio.entity.Statement;
+import com.example.pocketfolio.service.BillingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/billing")
+@RequiredArgsConstructor
+public class BillingController {
+
+    private final BillingService billingService;
+
+    // Manual close for a given credit card account
+    @PostMapping("/credit-cards/{accountId}/close")
+    public ResponseEntity<Statement> close(
+            @PathVariable UUID accountId,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        LocalDate d = (date != null) ? date : LocalDate.now();
+        Statement s = billingService.closeForAccountOnDate(accountId, d);
+        return ResponseEntity.ok(s);
+    }
+
+    // Manual autopay execution for statements due on date
+    @PostMapping("/autopay")
+    public ResponseEntity<Void> autopay(
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date
+    ) {
+        LocalDate d = (date != null) ? date : LocalDate.now();
+        billingService.autopayDueStatements(d);
+        return ResponseEntity.noContent().build();
+    }
+}
+

--- a/backend/src/main/java/com/example/pocketfolio/controller/BillingController.java
+++ b/backend/src/main/java/com/example/pocketfolio/controller/BillingController.java
@@ -1,7 +1,9 @@
 package com.example.pocketfolio.controller;
 
 import com.example.pocketfolio.entity.Statement;
+import com.example.pocketfolio.entity.StatementStatus;
 import com.example.pocketfolio.service.BillingService;
+import com.example.pocketfolio.repository.StatementRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
@@ -9,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
 import java.util.UUID;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/billing")
@@ -16,6 +19,7 @@ import java.util.UUID;
 public class BillingController {
 
     private final BillingService billingService;
+    private final StatementRepository statementRepository;
 
     // Manual close for a given credit card account
     @PostMapping("/credit-cards/{accountId}/close")
@@ -37,5 +41,17 @@ public class BillingController {
         billingService.autopayDueStatements(d);
         return ResponseEntity.noContent().build();
     }
-}
 
+    // Query statements due within window (for calendar planned items)
+    @GetMapping("/statements")
+    public ResponseEntity<List<Statement>> listStatements(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(required = false) UUID accountId
+    ) {
+        List<Statement> list = (accountId != null)
+                ? statementRepository.findByDueDateBetweenAndAccountId(from, to, accountId)
+                : statementRepository.findByDueDateBetween(from, to);
+        return ResponseEntity.ok(list);
+    }
+}

--- a/backend/src/main/java/com/example/pocketfolio/dto/AccountDto.java
+++ b/backend/src/main/java/com/example/pocketfolio/dto/AccountDto.java
@@ -1,0 +1,39 @@
+package com.example.pocketfolio.dto;
+
+import com.example.pocketfolio.entity.AccountType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountDto {
+    private UUID id;
+    private UUID userId;
+    private String name;
+    private AccountType type;
+    private String currencyCode;
+    private BigDecimal initialBalance;
+    private BigDecimal currentBalance;
+    private boolean includeInNetWorth;
+    private boolean archived;
+    private Integer closingDay;
+    private Integer dueDay;
+    private UUID autopayAccountId;
+    private short dueMonthOffset;
+    private String dueHolidayPolicy;
+    private boolean autopayEnabled;
+    private String notes;
+    private Instant createdAt;
+    private Instant updatedAt;
+}
+

--- a/backend/src/main/java/com/example/pocketfolio/entity/Statement.java
+++ b/backend/src/main/java/com/example/pocketfolio/entity/Statement.java
@@ -48,6 +48,14 @@ public class Statement {
     @Column(name = "status", nullable = false, length = 16)
     private StatementStatus status;
 
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "planned_tx_id")
+    private Transaction plannedTx;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "paid_tx_id")
+    private Transaction paidTx;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;
@@ -56,4 +64,3 @@ public class Statement {
     @Column(name = "updated_at", nullable = false)
     private Instant updatedAt;
 }
-

--- a/backend/src/main/java/com/example/pocketfolio/entity/Statement.java
+++ b/backend/src/main/java/com/example/pocketfolio/entity/Statement.java
@@ -1,0 +1,59 @@
+package com.example.pocketfolio.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.Instant;
+import java.util.UUID;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "statements")
+public class Statement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    private Account account;
+
+    @Column(name = "period_start", nullable = false)
+    private LocalDate periodStart;
+
+    @Column(name = "period_end", nullable = false)
+    private LocalDate periodEnd;
+
+    @Column(name = "closing_date", nullable = false)
+    private LocalDate closingDate;
+
+    @Column(name = "due_date", nullable = false)
+    private LocalDate dueDate;
+
+    @Column(name = "balance", nullable = false, precision = 18, scale = 2)
+    private BigDecimal balance;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private StatementStatus status;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}
+

--- a/backend/src/main/java/com/example/pocketfolio/entity/StatementStatus.java
+++ b/backend/src/main/java/com/example/pocketfolio/entity/StatementStatus.java
@@ -1,0 +1,9 @@
+package com.example.pocketfolio.entity;
+
+public enum StatementStatus {
+    OPEN,
+    CLOSED,
+    PAID,
+    PARTIAL
+}
+

--- a/backend/src/main/java/com/example/pocketfolio/entity/Transaction.java
+++ b/backend/src/main/java/com/example/pocketfolio/entity/Transaction.java
@@ -64,6 +64,14 @@ public class Transaction {
     @Column(name = "fx_rate_used", precision = 18, scale = 6)
     private BigDecimal fxRateUsed;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 16)
+    private TransactionStatus status = TransactionStatus.POSTED;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "statement_id")
+    private Statement statement;
+
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)
     private Instant createdAt;

--- a/backend/src/main/java/com/example/pocketfolio/entity/TransactionStatus.java
+++ b/backend/src/main/java/com/example/pocketfolio/entity/TransactionStatus.java
@@ -1,0 +1,7 @@
+package com.example.pocketfolio.entity;
+
+public enum TransactionStatus {
+    PENDING,
+    POSTED
+}
+

--- a/backend/src/main/java/com/example/pocketfolio/repository/AccountRepository.java
+++ b/backend/src/main/java/com/example/pocketfolio/repository/AccountRepository.java
@@ -1,11 +1,14 @@
 package com.example.pocketfolio.repository;
 
 import com.example.pocketfolio.entity.Account;
+import com.example.pocketfolio.entity.AccountType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
+import java.util.List;
 
 @Repository
 public interface AccountRepository extends JpaRepository<Account, UUID> {
+    List<Account> findByType(AccountType type);
 }

--- a/backend/src/main/java/com/example/pocketfolio/repository/StatementRepository.java
+++ b/backend/src/main/java/com/example/pocketfolio/repository/StatementRepository.java
@@ -8,10 +8,12 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
+import java.time.LocalDate;
 
 @Repository
 public interface StatementRepository extends JpaRepository<Statement, UUID> {
     List<Statement> findByAccountIdAndClosingDate(UUID accountId, LocalDate closingDate);
     List<Statement> findByDueDateAndStatus(LocalDate dueDate, StatementStatus status);
+    List<Statement> findByDueDateBetween(LocalDate from, LocalDate to);
+    List<Statement> findByDueDateBetweenAndAccountId(LocalDate from, LocalDate to, UUID accountId);
 }
-

--- a/backend/src/main/java/com/example/pocketfolio/repository/StatementRepository.java
+++ b/backend/src/main/java/com/example/pocketfolio/repository/StatementRepository.java
@@ -1,0 +1,17 @@
+package com.example.pocketfolio.repository;
+
+import com.example.pocketfolio.entity.Statement;
+import com.example.pocketfolio.entity.StatementStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+@Repository
+public interface StatementRepository extends JpaRepository<Statement, UUID> {
+    List<Statement> findByAccountIdAndClosingDate(UUID accountId, LocalDate closingDate);
+    List<Statement> findByDueDateAndStatus(LocalDate dueDate, StatementStatus status);
+}
+

--- a/backend/src/main/java/com/example/pocketfolio/service/BillingScheduler.java
+++ b/backend/src/main/java/com/example/pocketfolio/service/BillingScheduler.java
@@ -15,12 +15,11 @@ public class BillingScheduler {
 
     private static final ZoneId TAIPEI = ZoneId.of("Asia/Taipei");
 
-    // Daily close at 00:10 TPE (for cards whose closingDay == today.day)
+    // Daily close at 00:10 TPE: for cards whose closingDay == today.day (31 means month end)
     @Scheduled(cron = "0 10 0 * * *", zone = "Asia/Taipei")
     public void dailyClose() {
         LocalDate today = LocalDate.now(TAIPEI);
-        // In MVP, we rely on manual trigger per account; optional batch close can be added later
-        // Here we do nothing to avoid scanning all accounts. Endpoint allows manual close per account.
+        billingService.autoCloseForDay(today);
     }
 
     // Daily autopay at 00:20 TPE for due statements
@@ -30,4 +29,3 @@ public class BillingScheduler {
         billingService.autopayDueStatements(today);
     }
 }
-

--- a/backend/src/main/java/com/example/pocketfolio/service/BillingScheduler.java
+++ b/backend/src/main/java/com/example/pocketfolio/service/BillingScheduler.java
@@ -1,0 +1,33 @@
+package com.example.pocketfolio.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+@Component
+@RequiredArgsConstructor
+public class BillingScheduler {
+
+    private final BillingService billingService;
+
+    private static final ZoneId TAIPEI = ZoneId.of("Asia/Taipei");
+
+    // Daily close at 00:10 TPE (for cards whose closingDay == today.day)
+    @Scheduled(cron = "0 10 0 * * *", zone = "Asia/Taipei")
+    public void dailyClose() {
+        LocalDate today = LocalDate.now(TAIPEI);
+        // In MVP, we rely on manual trigger per account; optional batch close can be added later
+        // Here we do nothing to avoid scanning all accounts. Endpoint allows manual close per account.
+    }
+
+    // Daily autopay at 00:20 TPE for due statements
+    @Scheduled(cron = "0 20 0 * * *", zone = "Asia/Taipei")
+    public void dailyAutopay() {
+        LocalDate today = LocalDate.now(TAIPEI);
+        billingService.autopayDueStatements(today);
+    }
+}
+

--- a/backend/src/main/java/com/example/pocketfolio/service/BillingService.java
+++ b/backend/src/main/java/com/example/pocketfolio/service/BillingService.java
@@ -1,0 +1,143 @@
+package com.example.pocketfolio.service;
+
+import com.example.pocketfolio.dto.CreateTransactionRequest;
+import com.example.pocketfolio.entity.*;
+import com.example.pocketfolio.exception.NotFoundException;
+import com.example.pocketfolio.repository.AccountRepository;
+import com.example.pocketfolio.repository.StatementRepository;
+import com.example.pocketfolio.repository.TransactionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.*;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class BillingService {
+
+    private final AccountRepository accountRepository;
+    private final TransactionRepository transactionRepository;
+    private final StatementRepository statementRepository;
+    private final TransactionService transactionService;
+
+    @Transactional
+    public Statement closeForAccountOnDate(UUID accountId, LocalDate closingDate) {
+        Account card = accountRepository.findById(accountId)
+                .orElseThrow(() -> new NotFoundException("Account not found: " + accountId));
+        if (card.getType() != AccountType.CREDIT_CARD) {
+            throw new IllegalArgumentException("Only credit card accounts can be closed");
+        }
+
+        // Skip if already closed
+        List<Statement> exists = statementRepository.findByAccountIdAndClosingDate(accountId, closingDate);
+        if (!exists.isEmpty()) return exists.getFirst();
+
+        // Determine period: previous closingDate(exclusive) -> this closingDate(inclusive)
+        LocalDate prevClosing = previousClosingDate(closingDate, card.getClosingDay());
+        LocalDate periodStart = prevClosing.plusDays(1);
+        LocalDate periodEnd = closingDate;
+
+        // Sum CC transactions (income refunds reduce balance, expense increases)
+        Instant start = periodStart.atStartOfDay(ZoneOffset.UTC).toInstant();
+        Instant end = periodEnd.plusDays(1).atStartOfDay(ZoneOffset.UTC).toInstant();
+        BigDecimal balance = transactionRepository.findAll().stream()
+                .filter(tx -> tx.getAccount() != null && card.getId().equals(tx.getAccount().getId()))
+                .filter(tx -> !tx.getOccurredAt().isBefore(start) && tx.getOccurredAt().isBefore(end))
+                .map(tx -> switch (tx.getKind()) {
+                    case EXPENSE -> tx.getAmount();
+                    case INCOME -> tx.getAmount().negate();
+                    default -> BigDecimal.ZERO; // TRANSFER ignored in statement balance
+                })
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        LocalDate dueDate = computeDueDate(closingDate, card.getDueMonthOffset(), card.getDueDay(), card.getDueHolidayPolicy());
+
+        Statement stmt = new Statement();
+        stmt.setAccount(card);
+        stmt.setPeriodStart(periodStart);
+        stmt.setPeriodEnd(periodEnd);
+        stmt.setClosingDate(closingDate);
+        stmt.setDueDate(dueDate);
+        stmt.setBalance(balance);
+        stmt.setStatus(StatementStatus.CLOSED);
+        return statementRepository.save(stmt);
+    }
+
+    @Transactional
+    public void autopayDueStatements(LocalDate today) {
+        List<Statement> due = statementRepository.findByDueDateAndStatus(today, StatementStatus.CLOSED);
+        for (Statement s : due) {
+            Account card = s.getAccount();
+            if (!card.isAutopayEnabled() || card.getAutopayAccount() == null) continue;
+            Account src = card.getAutopayAccount();
+            BigDecimal amount = s.getBalance();
+            if (amount.compareTo(BigDecimal.ZERO) <= 0) {
+                s.setStatus(StatementStatus.PAID);
+                statementRepository.save(s);
+                continue;
+            }
+            BigDecimal available = src.getCurrentBalance();
+            BigDecimal pay = available.min(amount);
+            if (pay.compareTo(BigDecimal.ZERO) <= 0) continue;
+
+            CreateTransactionRequest req = new CreateTransactionRequest();
+            req.setUserId(card.getUserId());
+            req.setKind(TransactionKind.TRANSFER);
+            req.setAmount(pay);
+            req.setOccurredAt(today.atStartOfDay(ZoneOffset.UTC).toInstant());
+            req.setSourceAccountId(src.getId());
+            req.setTargetAccountId(card.getId());
+            req.setNotes("Autopay statement");
+            req.setCurrencyCode(card.getCurrencyCode());
+            transactionService.createTransaction(req);
+
+            BigDecimal remaining = amount.subtract(pay);
+            s.setBalance(remaining);
+            s.setStatus(remaining.compareTo(BigDecimal.ZERO) == 0 ? StatementStatus.PAID : StatementStatus.PARTIAL);
+            statementRepository.save(s);
+        }
+    }
+
+    // Utilities
+    public static LocalDate previousClosingDate(LocalDate closingDate, Integer closingDay) {
+        if (closingDay == null || closingDay < 1 || closingDay > 31) {
+            // fallback: previous month same date
+            return closingDate.minusMonths(1);
+        }
+        LocalDate prev = closingDate.minusMonths(1);
+        int dom = Math.min(closingDay, prev.lengthOfMonth());
+        return LocalDate.of(prev.getYear(), prev.getMonth(), dom);
+    }
+
+    public static LocalDate computeDueDate(LocalDate closingDate, short monthOffset, Integer dueDay, String policy) {
+        int offset = Math.max(0, Math.min(2, monthOffset));
+        LocalDate base = closingDate.plusMonths(offset);
+        int targetDay = (dueDay == null) ? base.getDayOfMonth() : Math.min(dueDay, 28);
+        if (dueDay != null && dueDay == 31) {
+            targetDay = base.lengthOfMonth();
+        }
+        LocalDate dt = LocalDate.of(base.getYear(), base.getMonth(), targetDay);
+        return adjustHoliday(dt, policy);
+    }
+
+    public static LocalDate adjustHoliday(LocalDate date, String policy) {
+        DayOfWeek dow = date.getDayOfWeek();
+        boolean isWeekend = (dow == DayOfWeek.SATURDAY || dow == DayOfWeek.SUNDAY);
+        if (!isWeekend || policy == null || policy.equals("NONE")) return date;
+        if (policy.equals("ADVANCE")) {
+            // move to previous Friday
+            if (dow == DayOfWeek.SATURDAY) return date.minusDays(1);
+            return date.minusDays(2);
+        } else if (policy.equals("POSTPONE")) {
+            // move to next Monday
+            if (dow == DayOfWeek.SATURDAY) return date.plusDays(2);
+            return date.plusDays(1);
+        }
+        return date;
+    }
+}
+

--- a/backend/src/main/java/com/example/pocketfolio/service/BillingService.java
+++ b/backend/src/main/java/com/example/pocketfolio/service/BillingService.java
@@ -68,6 +68,19 @@ public class BillingService {
     }
 
     @Transactional
+    public void autoCloseForDay(LocalDate today) {
+        // Find all credit cards and close those matching today as closing day (with 31 as month-end)
+        for (Account card : accountRepository.findByType(AccountType.CREDIT_CARD)) {
+            Integer cd = card.getClosingDay();
+            if (cd == null) continue;
+            boolean isMonthEnd = today.getDayOfMonth() == today.lengthOfMonth();
+            if ((cd == 31 && isMonthEnd) || (cd != 31 && today.getDayOfMonth() == cd)) {
+                closeForAccountOnDate(card.getId(), today);
+            }
+        }
+    }
+
+    @Transactional
     public void autopayDueStatements(LocalDate today) {
         List<Statement> due = statementRepository.findByDueDateAndStatus(today, StatementStatus.CLOSED);
         for (Statement s : due) {
@@ -140,4 +153,3 @@ public class BillingService {
         return date;
     }
 }
-

--- a/backend/src/main/resources/db/migration/V5__add_statements_table.sql
+++ b/backend/src/main/resources/db/migration/V5__add_statements_table.sql
@@ -1,0 +1,22 @@
+-- V5: credit card statements (MVP)
+
+CREATE TABLE statements (
+    id UUID PRIMARY KEY,
+    account_id UUID NOT NULL,
+    period_start DATE NOT NULL,
+    period_end DATE NOT NULL,
+    closing_date DATE NOT NULL,
+    due_date DATE NOT NULL,
+    balance DECIMAL(18,2) NOT NULL,
+    status VARCHAR(16) NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT fk_stmt_account FOREIGN KEY (account_id) REFERENCES accounts(id)
+);
+
+CREATE INDEX idx_statements_account ON statements(account_id);
+CREATE INDEX idx_statements_closing ON statements(closing_date);
+CREATE INDEX idx_statements_due ON statements(due_date);
+CREATE INDEX idx_statements_status ON statements(status);
+

--- a/backend/src/main/resources/db/migration/V6__planned_payment_and_links.sql
+++ b/backend/src/main/resources/db/migration/V6__planned_payment_and_links.sql
@@ -1,0 +1,24 @@
+-- V6: add planned/posted payment links and transaction status
+
+ALTER TABLE transactions
+  ADD COLUMN status VARCHAR(16) NOT NULL DEFAULT 'POSTED',
+  ADD COLUMN statement_id UUID;
+
+ALTER TABLE transactions
+  ADD CONSTRAINT chk_tx_status CHECK (status IN ('PENDING','POSTED'));
+
+ALTER TABLE transactions
+  ADD CONSTRAINT fk_tx_statement FOREIGN KEY (statement_id) REFERENCES statements(id);
+
+CREATE INDEX idx_transactions_statement ON transactions(statement_id);
+
+ALTER TABLE statements
+  ADD COLUMN planned_tx_id UUID,
+  ADD COLUMN paid_tx_id UUID;
+
+ALTER TABLE statements
+  ADD CONSTRAINT fk_stmt_planned_tx FOREIGN KEY (planned_tx_id) REFERENCES transactions(id);
+
+ALTER TABLE statements
+  ADD CONSTRAINT fk_stmt_paid_tx FOREIGN KEY (paid_tx_id) REFERENCES transactions(id);
+

--- a/backend/src/test/java/com/example/pocketfolio/service/BillingServiceTest.java
+++ b/backend/src/test/java/com/example/pocketfolio/service/BillingServiceTest.java
@@ -1,0 +1,30 @@
+package com.example.pocketfolio.service;
+
+import com.example.pocketfolio.entity.Account;
+import com.example.pocketfolio.entity.AccountType;
+import com.example.pocketfolio.repository.AccountRepository;
+import com.example.pocketfolio.repository.StatementRepository;
+import com.example.pocketfolio.repository.TransactionRepository;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+public class BillingServiceTest {
+
+    @Test
+    void compute_due_date_handles_month_end_and_weekend() {
+        // closing 2025-01-31, offset=1, dueDay=31 => 2025-02-(month end)
+        LocalDate closing = LocalDate.of(2025,1,31);
+        LocalDate due = BillingService.computeDueDate(closing, (short)1, 31, "NONE");
+        assertEquals(LocalDate.of(2025,2,28), due);
+
+        // weekend adjust: 2025-03-30 is Sunday; ADVANCE => 2025-03-28; POSTPONE => 2025-03-31
+        LocalDate dt = LocalDate.of(2025,3,30);
+        assertEquals(LocalDate.of(2025,3,28), BillingService.adjustHoliday(dt, "ADVANCE"));
+        assertEquals(LocalDate.of(2025,3,31), BillingService.adjustHoliday(dt, "POSTPONE"));
+    }
+}
+

--- a/docs/feature-specs/credit-card-billing.md
+++ b/docs/feature-specs/credit-card-billing.md
@@ -10,7 +10,7 @@ Last synced: 2025-09-14
 ## 使用者敘述與驗收（AC）
 - Given 信用卡設定好結帳/扣款日與預設扣款帳戶；When 到扣款日（依假日策略調整）；Then 系統建立轉帳交易，沖銷本期負債。
 
-## 規則與邊界
+## 規則與邊界（MVP 實作節錄）
 - 結帳邏輯：計算結帳區間內「未入前期帳單」的信用卡消費合計，生成當期帳單（可查閱/匯出）。
 - 扣款邏輯：扣款日建立轉帳交易（扣款帳戶 → 信用卡）。不足額時允許部分沖銷，餘額遞延。
 - 狀態：`statement.status ∈ {open, closed, paid, partial}`；交易需與 `statement_id` 關聯以利對帳。
@@ -22,9 +22,13 @@ Last synced: 2025-09-14
 - API：
   - POST `/credit-cards/{id}/statements/close`（手動結帳）
   - POST `/credit-cards/{id}/statements/{sid}/autopay`（重試自動扣款）
+  
+  MVP 已提供等效端點：
+  - `POST /api/billing/credit-cards/{accountId}/close?date=YYYY-MM-DD`
+  - `POST /api/billing/autopay?date=YYYY-MM-DD`
 
 ## 排程與冪等
-- 每日 00:10 執行結帳/扣款掃描（cron，Asia/Taipei）。
+- 每日 00:20 執行扣款掃描（cron，Asia/Taipei）。
 - 冪等 key：`statement_id + run_window`；重跑不得重複生成轉帳。
 
 ## 例外 / 錯誤

--- a/frontend/src/pages/AccountPage.tsx
+++ b/frontend/src/pages/AccountPage.tsx
@@ -20,6 +20,9 @@ interface Account {
     archived: boolean;
     closingDay?: number; // Optional
     dueDay?: number;     // Optional
+    // After backend DTOization, API returns autopayAccountId instead of nested account
+    autopayAccountId?: string;
+    // For backward compat (older responses), keep optional nested
     autopayAccount?: Account; // Self-referencing, optional
     // New optional fields returned by backend after V4
     dueMonthOffset?: 0 | 1 | 2; // 0|1|2
@@ -220,8 +223,8 @@ export function AccountPage() {
             dueDay: acc.dueDay ?? undefined,
             dueMonthOffset: (acc.dueMonthOffset ?? 1) as 0 | 1 | 2,
             dueHolidayPolicy: acc.dueHolidayPolicy ?? 'NONE',
-            autopayEnabled: (acc.autopayEnabled ?? false) || Boolean(acc.autopayAccount?.id),
-            autopayAccountId: acc.autopayAccount?.id,
+            autopayEnabled: (acc.autopayEnabled ?? false) || Boolean(acc.autopayAccountId ?? acc.autopayAccount?.id),
+            autopayAccountId: acc.autopayAccountId ?? acc.autopayAccount?.id,
             notes: acc.notes ?? '',
         });
     };

--- a/frontend/src/pages/TransactionsCalendarPage.tsx
+++ b/frontend/src/pages/TransactionsCalendarPage.tsx
@@ -18,13 +18,7 @@ interface TxItem {
   notes?: string | null;
 }
 
-interface StatementItem {
-  id: string;
-  account: { id: string } | null; // backend currently returns entity; DTOization could be added later
-  dueDate: string; // ISO date
-  balance: number;
-  status: 'OPEN' | 'CLOSED' | 'PAID' | 'PARTIAL';
-}
+// Planned/posted autopay are returned in transactions; no separate StatementItem needed
 
 interface Account { id: string; name: string; currencyCode: string; archived: boolean; type: string; currentBalance: number; }
 interface CategoryNode { id: string; name: string; children?: CategoryNode[] }
@@ -67,7 +61,7 @@ export function TransactionsCalendarPage() {
   const [notes, setNotes] = useState<string>('');
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [categories, setCategories] = useState<CategoryNode[]>([]);
-  const [plans, setPlans] = useState<StatementItem[]>([]);
+  // No separate plans state; rely solely on transactions
 
   const monthStart = startOfMonth(cursor);
   const monthEnd = endOfMonth(cursor);
@@ -83,16 +77,6 @@ export function TransactionsCalendarPage() {
         const data = await res.json();
         const list: TxItem[] = (data.content ?? data) as TxItem[]; // support Page or array
         setItems(list);
-        // Fetch planned statements (due within this month window)
-        const fromDate = fromISO.substring(0, 10);
-        const toDate = toISO.substring(0, 10);
-        const res2 = await fetch(`${API_STM}?from=${fromDate}&to=${toDate}`);
-        if (res2.ok) {
-          const stm: StatementItem[] = await res2.json();
-          setPlans(stm);
-        } else {
-          setPlans([]);
-        }
       } catch (e) {
         console.error(e);
         alert('載入交易失敗');

--- a/frontend/src/pages/TransactionsCalendarPage.tsx
+++ b/frontend/src/pages/TransactionsCalendarPage.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 
 const API_TX = 'http://localhost:8080/api/transactions';
-const API_STM = 'http://localhost:8080/api/billing/statements';
 const API_ACCOUNTS = 'http://localhost:8080/api/accounts';
 const API_CATEGORIES = 'http://localhost:8080/api/categories';
 
@@ -134,11 +133,6 @@ export function TransactionsCalendarPage() {
       const d = new Date(it.occurredAt);
       const key = ymd(new Date(d.getFullYear(), d.getMonth(), d.getDate()));
       map.set(key, (map.get(key) ?? 0) + 1);
-    }
-    for (const p of plans) {
-      const d = new Date(p.dueDate);
-      const key = ymd(new Date(d.getFullYear(), d.getMonth(), d.getDate()));
-      map.set(key, (map.get(key) ?? 0) + 0); // don't count as transaction, but ensure key exists
     }
     return map;
   }, [items]);
@@ -287,17 +281,10 @@ export function TransactionsCalendarPage() {
           if (!cell.date) return <div key={idx} />;
           const label = ymd(cell.date);
           const count = countsByDay.get(label) ?? 0;
-          const hasPlan = plans.some(p => {
-            const dd = new Date(p.dueDate);
-            return ymd(new Date(dd.getFullYear(), dd.getMonth(), dd.getDate())) === label && (p.status === 'CLOSED' || p.status === 'PARTIAL');
-          });
           return (
             <div key={idx} style={{ border: '1px solid #ddd', padding: '6px', minHeight: '60px', cursor: 'pointer' }} onClick={() => openModal(cell.date!)}>
               <div style={{ fontSize: '12px', opacity: 0.8 }}>{cell.date.getDate()}</div>
               <div style={{ fontSize: '12px' }}>{count > 0 ? `${count} 筆` : ''}</div>
-              {hasPlan && (
-                <div style={{ marginTop: 4, fontSize: 11, color: '#1565c0' }}>預備扣款</div>
-              )}
             </div>
           );
         })}
@@ -309,7 +296,7 @@ export function TransactionsCalendarPage() {
             <h3>建立交易（{selectedDate}）</h3>
             {/* Existing items for the day (summary list) */}
             <div style={{ maxHeight: 200, overflow: 'auto', marginBottom: 8, border: '1px solid #eee', padding: 8 }}>
-              {itemsOfSelectedDay.length === 0 && plans.filter(p => ymd(new Date(p.dueDate)) === selectedDate && (p.status === 'CLOSED' || p.status === 'PARTIAL')).length === 0 ? (
+              {itemsOfSelectedDay.length === 0 ? (
                 <div style={{ fontSize: 12, color: '#777' }}>當日尚無交易</div>
               ) : (
                 <div>
@@ -321,17 +308,6 @@ export function TransactionsCalendarPage() {
                     <div>使用者</div>
                     <div>操作</div>
                   </div>
-                  {/* Planned statements first */}
-                  {plans.filter(p => ymd(new Date(p.dueDate)) === selectedDate && (p.status === 'CLOSED' || p.status === 'PARTIAL')).map(p => (
-                    <div key={`plan-${p.id}`} style={{ display: 'grid', gridTemplateColumns: '120px 1fr 1fr 1fr 120px 80px', gap: 8, alignItems: 'center', padding: '6px 0', borderBottom: '1px solid #f7f7f7' }}>
-                      <div style={{ color: '#1565c0', fontWeight: 700 }}>{p.balance.toLocaleString()}</div>
-                      <div style={{ color: '#222' }}>預備扣款</div>
-                      <div style={{ color: '#222' }}>扣款帳戶 → 信用卡</div>
-                      <div style={{ color: '#444' }}>{p.status === 'PARTIAL' ? '前期部分未清' : ''}</div>
-                      <div style={{ color: '#222' }}></div>
-                      <div style={{ color: '#888' }}>預備</div>
-                    </div>
-                  ))}
                   {itemsOfSelectedDay.map((it) => {
                     const color = it.kind === 'INCOME' ? '#138a36' : it.kind === 'EXPENSE' ? '#c62828' : '#1565c0';
                     const sign = it.kind === 'INCOME' ? '+' : it.kind === 'EXPENSE' ? '-' : '';


### PR DESCRIPTION
  - Summary
      - 將「預備扣款」實作為真正的交易：繳款日建立 PENDING TRANSFER，繳款日當天轉為 POSTED 並實際入帳
      - 期間內信用卡交易（支出/退款）即時累加到當期預備交易；繳款日後變動則 in-place 調整已入帳交易金額並同步帳戶餘額與帳單狀態
      - 自動化：每日 00:10 自動結帳（依 closingDay），每日 00:20 自動扣款（dueMonthOffset + dueDay + 週末假日策略）
      - 月曆頁改為直接顯示預備/入帳交易，不再依賴 /api/billing/statements；修復因 JPA Lazy Proxy 導致的 500 問題（移除該端點在前端的使用）
  - DB Migrations
      - V5: statements 表（period/closing/due/balance/status）
      - V6: transactions 新增 status(PENDING|POSTED), statement_id；statements 新增 planned_tx_id, paid_tx_id
      - V7: 放寬 amount 檢核，允許 status=PENDING 時 amount >= 0（POSTED 仍需 > 0）
  - Backend
      - BillingService：ensureOpen（期初建立 OPEN + PENDING）、closeForAccount、autopayDueStatements（轉 POSTED 入帳）、autoCloseForDay（每日 00:10）
      - TransactionService：信用卡 INCOME/EXPENSE create/delete 觸發即時重算，更新 PENDING 或 in-place 調整 POSTED 與帳戶餘額/帳單狀態
      - Accounts API 回傳 DTO（autopayAccountId），避免 Lazy Proxy 序列化錯誤
  - Frontend
      - 月曆頁只用 /api/transactions；移除「預備扣款」純文字標記與 /api/billing/statements 呼叫
      - 預備/入帳交易在繳款日以一般交易出現，金額會隨期間內交易即時更新
  - Verification
      - 建立信用卡/銀行帳戶與設定（closingDay/dueDay/dueMonthOffset/holiday/autopay）
      - 期初自動建立繳款日 PENDING 交易（amount=0）
      - 期間刷卡會即時更新繳款日那筆 PENDING 交易金額
      - 到期日自動（或手動）入帳，PENDING→POSTED 並實際扣款；繳款日後調整交易會 in-place 調整 POSTED 交易金額
  - Risk & Rollback
      - Schema 增量，Flyway 遷移可回滾（需逆向遷移）；前端已去除對 statements 的依賴降低脆弱性

  PR 連結

  - https://github.com/WIse4466/pocketfolio/pull/new/feature/cc-billing-autopay