### PR TITLE
feat(auth): auto-redirect to login on token expiry

### DIFF
--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -1,5 +1,6 @@
-import axios, { type AxiosError, type AxiosRequestConfig, type AxiosResponse } from 'axios';
+import axios, { type AxiosError, type AxiosResponse } from 'axios';
 import { message } from 'antd';
+import { useAuthStore } from '@/store/authStore';
 
 // 創建 Axios 實例
 const axiosInstance = axios.create({
@@ -40,11 +41,12 @@ axiosInstance.interceptors.response.use(
 
       switch (status) {
         case 401:
-          // 未授權，清除 Token 並跳轉到登入頁
-          localStorage.removeItem('token');
-          localStorage.removeItem('user');
-          message.error('登入已過期，請重新登入');
-          window.location.href = '/login';
+          // 登入/註冊本身失敗不處理，讓各自頁面顯示錯誤
+          if (!error.config?.url?.startsWith('/auth/')) {
+            useAuthStore.getState().logout();
+            message.error('登入已過期，請重新登入');
+            window.location.href = '/login';
+          }
           break;
         
         case 403:

--- a/frontend/src/api/axios.ts
+++ b/frontend/src/api/axios.ts
@@ -42,9 +42,10 @@ axiosInstance.interceptors.response.use(
       switch (status) {
         case 401:
           // 登入/註冊本身失敗不處理，讓各自頁面顯示錯誤
-          if (!error.config?.url?.startsWith('/auth/')) {
+          if (!error.config?.url?.includes('/auth/')) {
             useAuthStore.getState().logout();
             message.error('登入已過期，請重新登入');
+            // 使用 hard redirect 確保 React 記憶體狀態完全清除後再重新初始化
             window.location.href = '/login';
           }
           break;

--- a/frontend/src/pages/auth/Login.tsx
+++ b/frontend/src/pages/auth/Login.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { Form, Input, Button, Card, Typography, message, Divider } from 'antd';
 import { LockOutlined, MailOutlined } from '@ant-design/icons';
+import axios from 'axios';
 import { authApi } from '@/api/auth.api';
 import { useAuthStore } from '@/store/authStore';
 import type { LoginRequest } from '@/types/auth.types';
@@ -20,9 +21,12 @@ const Login = () => {
       login(response);
       message.success('登入成功！');
       navigate('/');
-    } catch (error: any) {
-      const msg = error?.response?.data?.message;
-      message.error(msg || '帳號或密碼錯誤');
+    } catch (error: unknown) {
+      let msg = '帳號或密碼錯誤';
+      if (axios.isAxiosError(error)) {
+        msg = error.response?.data?.message || msg;
+      }
+      message.error(msg);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/auth/Login.tsx
+++ b/frontend/src/pages/auth/Login.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { Form, Input, Button, Card, Typography, message, Divider } from 'antd';
-import { UserOutlined, LockOutlined, MailOutlined } from '@ant-design/icons';
+import { LockOutlined, MailOutlined } from '@ant-design/icons';
 import { authApi } from '@/api/auth.api';
 import { useAuthStore } from '@/store/authStore';
 import type { LoginRequest } from '@/types/auth.types';
@@ -21,8 +21,8 @@ const Login = () => {
       message.success('登入成功！');
       navigate('/');
     } catch (error: any) {
-      // 錯誤已在 axios 攔截器處理
-      console.error('登入失敗:', error);
+      const msg = error?.response?.data?.message;
+      message.error(msg || '帳號或密碼錯誤');
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/auth/Register.tsx
+++ b/frontend/src/pages/auth/Register.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import { Form, Input, Button, Card, Typography, message, Divider } from 'antd';
 import { UserOutlined, LockOutlined, MailOutlined } from '@ant-design/icons';
+import axios from 'axios';
 import { authApi } from '@/api/auth.api';
 import { useAuthStore } from '@/store/authStore';
 import type { RegisterRequest } from '@/types/auth.types';
@@ -20,9 +21,12 @@ const Register = () => {
       login(response);
       message.success('註冊成功！');
       navigate('/');
-    } catch (error: any) {
-      const msg = error?.response?.data?.message;
-      message.error(msg || '註冊失敗，請稍後再試');
+    } catch (error: unknown) {
+      let msg = '註冊失敗，請稍後再試';
+      if (axios.isAxiosError(error)) {
+        msg = error.response?.data?.message || msg;
+      }
+      message.error(msg);
     } finally {
       setLoading(false);
     }

--- a/frontend/src/pages/auth/Register.tsx
+++ b/frontend/src/pages/auth/Register.tsx
@@ -21,7 +21,8 @@ const Register = () => {
       message.success('註冊成功！');
       navigate('/');
     } catch (error: any) {
-      console.error('註冊失敗:', error);
+      const msg = error?.response?.data?.message;
+      message.error(msg || '註冊失敗，請稍後再試');
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- axios 401 interceptor 改用 `useAuthStore.getState().logout()` 清除 Zustand `auth-storage`，解決原本 redirect 後因 re-hydration 導致跳回首頁的問題
- 排除 `/auth/` 路徑的 401 處理，避免登入/註冊失敗時誤觸 redirect
- Login、Register 頁面的 catch 改為顯示後端錯誤訊息

## Test plan
- [ ] 登入填錯密碼 → 顯示錯誤訊息，不跳頁
- [ ] Console 執行 `localStorage.setItem('token', 'invalidtoken123')`，切換頁面 → 顯示「登入已過期」並跳到 `/login`
- [ ] 正常登入/登出流程不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)