### PR TITLE
fix(websocket): add Firebase Hosting domains to WebSocket allowed origins

### DIFF
--- a/backend/src/main/java/com/pocketfolio/backend/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/pocketfolio/backend/config/WebSocketConfig.java
@@ -35,8 +35,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
                 .setAllowedOrigins(
-                        "http://localhost:5173",  // Vite
-                        "http://localhost:3000"   // React
+                        "http://localhost:5173",                    // Vite
+                        "http://localhost:3000",                    // React
+                        "https://pocketfolio-prod.web.app",        // Firebase Hosting
+                        "https://pocketfolio-prod.firebaseapp.com" // Firebase Hosting (備用網域)
                 )
                 .withSockJS();  // 支援 SockJS（瀏覽器不支援 WebSocket 時的降級方案）
     }


### PR DESCRIPTION
## Summary
- Spring WebSocket 的 `setAllowedOrigins` 與 `SecurityConfig` 的 CORS 設定是獨立的
- 生產環境 SockJS handshake（`/ws/info`）回傳 403，原因是 Firebase Hosting 網域未加入 WebSocket 允許清單

## Root Cause
`WebSocketConfig.setAllowedOrigins` 只有 localhost，導致來自 `pocketfolio-prod.web.app` 的連線被擋

## Test plan
- [x] 部署後到 https://pocketfolio-prod.web.app 登入
- [x] DevTools → Network → 篩選 WS，確認 WebSocket 連線建立成功（101 Switching Protocols）
- [x] 等待 5 分鐘，確認收到價格更新訊息

🤖 Generated with [Claude Code](https://claude.com/claude-code)