### PR TITLE
feat(dashboard): connect real data and enable statistics page

### DIFF
--- a/backend/src/main/java/com/pocketfolio/backend/config/WebSocketConfig.java
+++ b/backend/src/main/java/com/pocketfolio/backend/config/WebSocketConfig.java
@@ -35,8 +35,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws")
                 .setAllowedOrigins(
-                        "http://localhost:5173",  // Vite
-                        "http://localhost:3000"   // React
+                        "http://localhost:5173",                    // Vite
+                        "http://localhost:3000",                    // React
+                        "https://pocketfolio-prod.web.app",        // Firebase Hosting
+                        "https://pocketfolio-prod.firebaseapp.com" // Firebase Hosting (備用網域)
                 )
                 .withSockJS();  // 支援 SockJS（瀏覽器不支援 WebSocket 時的降級方案）
     }

--- a/frontend/src/api/statistics.api.ts
+++ b/frontend/src/api/statistics.api.ts
@@ -1,20 +1,19 @@
 import axios from './axios';
 
+export interface CategoryStat {
+  categoryName: string;
+  amount: number;
+  percentage: number;
+}
+
 export interface MonthlyStatistics {
   year: number;
   month: number;
   totalIncome: number;
   totalExpense: number;
   netAmount: number;
-  transactionCount: number;
-  categoryBreakdown: {
-    categoryId: string;
-    categoryName: string;
-    categoryType: 'INCOME' | 'EXPENSE';
-    totalAmount: number;
-    transactionCount: number;
-    percentage: number;
-  }[];
+  incomeByCategory: CategoryStat[];
+  expenseByCategory: CategoryStat[];
 }
 
 export interface AccountBalance {

--- a/frontend/src/components/Layout/MainLayout.tsx
+++ b/frontend/src/components/Layout/MainLayout.tsx
@@ -75,7 +75,6 @@ const MainLayout = () => {
       icon: <LineChartOutlined />,
       label: '統計分析',
       onClick: () => navigate('/statistics'),
-      disabled: true, // Phase 6 實作
     },
   ];
 

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -1,25 +1,69 @@
-import { Card, Row, Col, Statistic, Typography } from 'antd';
+import { useEffect, useState } from 'react';
+import { Card, Row, Col, Statistic, Typography, Spin, Alert } from 'antd';
 import {
   DollarOutlined,
   RiseOutlined,
   FallOutlined,
   WalletOutlined,
 } from '@ant-design/icons';
+import { statisticsApi, type MonthlyStatistics, type AccountBalance } from '@/api/statistics.api';
+import { accountApi } from '@/api/account.api';
 
 const { Title } = Typography;
 
 const Dashboard = () => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [monthlyStats, setMonthlyStats] = useState<MonthlyStatistics | null>(null);
+  const [accountBalances, setAccountBalances] = useState<AccountBalance[]>([]);
+  const [accountCount, setAccountCount] = useState(0);
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const now = new Date();
+        const [stats, balances, accounts] = await Promise.all([
+          statisticsApi.getMonthlyStatistics(now.getFullYear(), now.getMonth() + 1),
+          statisticsApi.getAccountBalances(),
+          accountApi.getAccounts(),
+        ]);
+        setMonthlyStats(stats);
+        setAccountBalances(balances);
+        setAccountCount(accounts.length);
+      } catch {
+        setError('載入資料失敗，請重新整理');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, []);
+
+  const totalBalance = accountBalances.reduce((sum, a) => sum + a.currentBalance, 0);
+
+  if (loading) {
+    return (
+      <div style={{ textAlign: 'center', padding: '60px 0' }}>
+        <Spin size="large" />
+      </div>
+    );
+  }
+
   return (
     <div>
       <Title level={2}>控制台</Title>
 
-      {/* 統計卡片 */}
+      {error && (
+        <Alert type="error" message={error} style={{ marginBottom: 16 }} />
+      )}
+
       <Row gutter={[16, 16]}>
         <Col xs={24} sm={12} lg={6}>
           <Card>
             <Statistic
-              title="總資產"
-              value={150000}
+              title="帳戶總餘額"
+              value={totalBalance}
               precision={0}
               valueStyle={{ color: '#3f8600' }}
               prefix={<DollarOutlined />}
@@ -32,7 +76,7 @@ const Dashboard = () => {
           <Card>
             <Statistic
               title="本月收入"
-              value={50000}
+              value={monthlyStats?.totalIncome ?? 0}
               precision={0}
               valueStyle={{ color: '#3f8600' }}
               prefix={<RiseOutlined />}
@@ -45,7 +89,7 @@ const Dashboard = () => {
           <Card>
             <Statistic
               title="本月支出"
-              value={30000}
+              value={monthlyStats?.totalExpense ?? 0}
               precision={0}
               valueStyle={{ color: '#cf1322' }}
               prefix={<FallOutlined />}
@@ -58,21 +102,17 @@ const Dashboard = () => {
           <Card>
             <Statistic
               title="帳戶數量"
-              value={5}
+              value={accountCount}
               prefix={<WalletOutlined />}
             />
           </Card>
         </Col>
       </Row>
 
-      {/* 提示訊息 */}
       <Card style={{ marginTop: '24px' }}>
         <Title level={4}>歡迎使用 PocketFolio！</Title>
         <p>這是一個個人財務管理系統，幫助你追蹤收支、管理資產。</p>
         <p>請從左側選單開始使用各項功能。</p>
-        <p style={{ color: '#999', fontSize: '12px' }}>
-          註：統計數據將在 Phase 6 整合真實 API
-        </p>
       </Card>
     </div>
   );

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -20,21 +20,21 @@ const Dashboard = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      try {
-        const now = new Date();
-        const [stats, balances, accounts] = await Promise.all([
-          statisticsApi.getMonthlyStatistics(now.getFullYear(), now.getMonth() + 1),
-          statisticsApi.getAccountBalances(),
-          accountApi.getAccounts(),
-        ]);
-        setMonthlyStats(stats);
-        setAccountBalances(balances);
-        setAccountCount(accounts.length);
-      } catch {
-        setError('載入資料失敗，請重新整理');
-      } finally {
-        setLoading(false);
-      }
+      const now = new Date();
+      const [statsResult, balancesResult, accountsResult] = await Promise.allSettled([
+        statisticsApi.getMonthlyStatistics(now.getFullYear(), now.getMonth() + 1),
+        statisticsApi.getAccountBalances(),
+        accountApi.getAccounts(),
+      ]);
+
+      if (statsResult.status === 'fulfilled') setMonthlyStats(statsResult.value);
+      if (balancesResult.status === 'fulfilled') setAccountBalances(balancesResult.value);
+      if (accountsResult.status === 'fulfilled') setAccountCount(accountsResult.value.length);
+
+      const allFailed = [statsResult, balancesResult, accountsResult].every(r => r.status === 'rejected');
+      if (allFailed) setError('載入資料失敗，請重新整理');
+
+      setLoading(false);
     };
 
     fetchData();

--- a/frontend/src/pages/statistics/StatisticsPage.tsx
+++ b/frontend/src/pages/statistics/StatisticsPage.tsx
@@ -1,0 +1,208 @@
+import { useEffect, useState } from 'react';
+import { Card, Row, Col, Statistic, Typography, Spin, Alert, DatePicker, Table, Tag } from 'antd';
+import { RiseOutlined, FallOutlined, SwapOutlined } from '@ant-design/icons';
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+import dayjs, { type Dayjs } from 'dayjs';
+import { statisticsApi, type MonthlyStatistics } from '@/api/statistics.api';
+
+const { Title } = Typography;
+
+const COLORS = ['#1890ff', '#52c41a', '#faad14', '#f5222d', '#722ed1', '#13c2c2', '#eb2f96', '#fa8c16'];
+
+const StatisticsPage = () => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [stats, setStats] = useState<MonthlyStatistics | null>(null);
+  const [selectedDate, setSelectedDate] = useState<Dayjs>(dayjs());
+
+  const fetchStats = async (date: Dayjs) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await statisticsApi.getMonthlyStatistics(date.year(), date.month() + 1);
+      setStats(data);
+    } catch {
+      setError('載入統計資料失敗');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchStats(selectedDate);
+  }, [selectedDate]);
+
+  const expenseBreakdown = stats?.categoryBreakdown?.filter(c => c.categoryType === 'EXPENSE') ?? [];
+  const incomeBreakdown = stats?.categoryBreakdown?.filter(c => c.categoryType === 'INCOME') ?? [];
+
+  const columns = [
+    { title: '類別', dataIndex: 'categoryName', key: 'categoryName' },
+    {
+      title: '金額',
+      dataIndex: 'totalAmount',
+      key: 'totalAmount',
+      render: (v: number) => `$${v.toLocaleString()}`,
+      sorter: (a: any, b: any) => b.totalAmount - a.totalAmount,
+    },
+    {
+      title: '佔比',
+      dataIndex: 'percentage',
+      key: 'percentage',
+      render: (v: number) => `${v.toFixed(1)}%`,
+    },
+    { title: '筆數', dataIndex: 'transactionCount', key: 'transactionCount' },
+  ];
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 16, marginBottom: 24 }}>
+        <Title level={2} style={{ margin: 0 }}>統計分析</Title>
+        <DatePicker
+          picker="month"
+          value={selectedDate}
+          onChange={(date) => date && setSelectedDate(date)}
+          allowClear={false}
+        />
+      </div>
+
+      {error && <Alert type="error" message={error} style={{ marginBottom: 16 }} />}
+
+      {loading ? (
+        <div style={{ textAlign: 'center', padding: '60px 0' }}>
+          <Spin size="large" />
+        </div>
+      ) : (
+        <>
+          {/* 月度摘要 */}
+          <Row gutter={[16, 16]}>
+            <Col xs={24} sm={8}>
+              <Card>
+                <Statistic
+                  title="本月收入"
+                  value={stats?.totalIncome ?? 0}
+                  precision={0}
+                  valueStyle={{ color: '#3f8600' }}
+                  prefix={<RiseOutlined />}
+                  suffix="TWD"
+                />
+              </Card>
+            </Col>
+            <Col xs={24} sm={8}>
+              <Card>
+                <Statistic
+                  title="本月支出"
+                  value={stats?.totalExpense ?? 0}
+                  precision={0}
+                  valueStyle={{ color: '#cf1322' }}
+                  prefix={<FallOutlined />}
+                  suffix="TWD"
+                />
+              </Card>
+            </Col>
+            <Col xs={24} sm={8}>
+              <Card>
+                <Statistic
+                  title="本月結餘"
+                  value={stats?.netAmount ?? 0}
+                  precision={0}
+                  valueStyle={{ color: (stats?.netAmount ?? 0) >= 0 ? '#3f8600' : '#cf1322' }}
+                  prefix={<SwapOutlined />}
+                  suffix="TWD"
+                />
+              </Card>
+            </Col>
+          </Row>
+
+          {/* 支出分析 */}
+          {expenseBreakdown.length > 0 && (
+            <Row gutter={[16, 16]} style={{ marginTop: 16 }}>
+              <Col xs={24} lg={10}>
+                <Card title={<><Tag color="red">支出</Tag>類別圓餅圖</>}>
+                  <ResponsiveContainer width="100%" height={260}>
+                    <PieChart>
+                      <Pie
+                        data={expenseBreakdown}
+                        dataKey="totalAmount"
+                        nameKey="categoryName"
+                        cx="50%"
+                        cy="50%"
+                        outerRadius={90}
+                        label={({ categoryName, percentage }: any) => `${categoryName} ${Number(percentage).toFixed(0)}%`}
+                        labelLine={false}
+                      >
+                        {expenseBreakdown.map((_, i) => (
+                          <Cell key={i} fill={COLORS[i % COLORS.length]} />
+                        ))}
+                      </Pie>
+                      <Tooltip formatter={(v) => [`$${Number(v).toLocaleString()}`]} />
+                    </PieChart>
+                  </ResponsiveContainer>
+                </Card>
+              </Col>
+              <Col xs={24} lg={14}>
+                <Card title={<><Tag color="red">支出</Tag>明細</>}>
+                  <Table
+                    dataSource={expenseBreakdown}
+                    columns={columns}
+                    rowKey="categoryId"
+                    pagination={false}
+                    size="small"
+                  />
+                </Card>
+              </Col>
+            </Row>
+          )}
+
+          {/* 收入分析 */}
+          {incomeBreakdown.length > 0 && (
+            <Row gutter={[16, 16]} style={{ marginTop: 16 }}>
+              <Col xs={24} lg={10}>
+                <Card title={<><Tag color="green">收入</Tag>類別圓餅圖</>}>
+                  <ResponsiveContainer width="100%" height={260}>
+                    <PieChart>
+                      <Pie
+                        data={incomeBreakdown}
+                        dataKey="totalAmount"
+                        nameKey="categoryName"
+                        cx="50%"
+                        cy="50%"
+                        outerRadius={90}
+                        label={({ categoryName, percentage }: any) => `${categoryName} ${Number(percentage).toFixed(0)}%`}
+                        labelLine={false}
+                      >
+                        {incomeBreakdown.map((_, i) => (
+                          <Cell key={i} fill={COLORS[i % COLORS.length]} />
+                        ))}
+                      </Pie>
+                      <Tooltip formatter={(v) => [`$${Number(v).toLocaleString()}`]} />
+                      <Legend />
+                    </PieChart>
+                  </ResponsiveContainer>
+                </Card>
+              </Col>
+              <Col xs={24} lg={14}>
+                <Card title={<><Tag color="green">收入</Tag>明細</>}>
+                  <Table
+                    dataSource={incomeBreakdown}
+                    columns={columns}
+                    rowKey="categoryId"
+                    pagination={false}
+                    size="small"
+                  />
+                </Card>
+              </Col>
+            </Row>
+          )}
+
+          {expenseBreakdown.length === 0 && incomeBreakdown.length === 0 && (
+            <Card style={{ marginTop: 16, textAlign: 'center', color: '#999' }}>
+              本月尚無交易記錄
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default StatisticsPage;

--- a/frontend/src/pages/statistics/StatisticsPage.tsx
+++ b/frontend/src/pages/statistics/StatisticsPage.tsx
@@ -3,11 +3,12 @@ import { Card, Row, Col, Statistic, Typography, Spin, Alert, DatePicker, Table, 
 import { RiseOutlined, FallOutlined, SwapOutlined } from '@ant-design/icons';
 import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 import dayjs, { type Dayjs } from 'dayjs';
-import { statisticsApi, type MonthlyStatistics } from '@/api/statistics.api';
+import { statisticsApi, type MonthlyStatistics, type CategoryStat } from '@/api/statistics.api';
 
 const { Title } = Typography;
 
 const COLORS = ['#1890ff', '#52c41a', '#faad14', '#f5222d', '#722ed1', '#13c2c2', '#eb2f96', '#fa8c16'];
+
 
 const StatisticsPage = () => {
   const [loading, setLoading] = useState(true);
@@ -32,17 +33,17 @@ const StatisticsPage = () => {
     fetchStats(selectedDate);
   }, [selectedDate]);
 
-  const expenseBreakdown = stats?.categoryBreakdown?.filter(c => c.categoryType === 'EXPENSE') ?? [];
-  const incomeBreakdown = stats?.categoryBreakdown?.filter(c => c.categoryType === 'INCOME') ?? [];
+  const expenseBreakdown = stats?.expenseByCategory ?? [];
+  const incomeBreakdown = stats?.incomeByCategory ?? [];
 
   const columns = [
     { title: '類別', dataIndex: 'categoryName', key: 'categoryName' },
     {
       title: '金額',
-      dataIndex: 'totalAmount',
-      key: 'totalAmount',
+      dataIndex: 'amount',
+      key: 'amount',
       render: (v: number) => `$${v.toLocaleString()}`,
-      sorter: (a: any, b: any) => b.totalAmount - a.totalAmount,
+      sorter: (a: CategoryStat, b: CategoryStat) => b.amount - a.amount,
     },
     {
       title: '佔比',
@@ -50,7 +51,6 @@ const StatisticsPage = () => {
       key: 'percentage',
       render: (v: number) => `${v.toFixed(1)}%`,
     },
-    { title: '筆數', dataIndex: 'transactionCount', key: 'transactionCount' },
   ];
 
   return (
@@ -122,12 +122,12 @@ const StatisticsPage = () => {
                     <PieChart>
                       <Pie
                         data={expenseBreakdown}
-                        dataKey="totalAmount"
+                        dataKey="amount"
                         nameKey="categoryName"
                         cx="50%"
                         cy="50%"
                         outerRadius={90}
-                        label={({ categoryName, percentage }: any) => `${categoryName} ${Number(percentage).toFixed(0)}%`}
+                        label={({ name, percent }) => `${name} ${((percent ?? 0) * 100).toFixed(0)}%`}
                         labelLine={false}
                       >
                         {expenseBreakdown.map((_, i) => (
@@ -144,7 +144,7 @@ const StatisticsPage = () => {
                   <Table
                     dataSource={expenseBreakdown}
                     columns={columns}
-                    rowKey="categoryId"
+                    rowKey="categoryName"
                     pagination={false}
                     size="small"
                   />
@@ -162,12 +162,12 @@ const StatisticsPage = () => {
                     <PieChart>
                       <Pie
                         data={incomeBreakdown}
-                        dataKey="totalAmount"
+                        dataKey="amount"
                         nameKey="categoryName"
                         cx="50%"
                         cy="50%"
                         outerRadius={90}
-                        label={({ categoryName, percentage }: any) => `${categoryName} ${Number(percentage).toFixed(0)}%`}
+                        label={({ name, percent }) => `${name} ${((percent ?? 0) * 100).toFixed(0)}%`}
                         labelLine={false}
                       >
                         {incomeBreakdown.map((_, i) => (
@@ -185,7 +185,7 @@ const StatisticsPage = () => {
                   <Table
                     dataSource={incomeBreakdown}
                     columns={columns}
-                    rowKey="categoryId"
+                    rowKey="categoryName"
                     pagination={false}
                     size="small"
                   />
@@ -194,7 +194,7 @@ const StatisticsPage = () => {
             </Row>
           )}
 
-          {expenseBreakdown.length === 0 && incomeBreakdown.length === 0 && (
+          {(stats?.totalIncome === 0 && stats?.totalExpense === 0) && (
             <Card style={{ marginTop: 16, textAlign: 'center', color: '#999' }}>
               本月尚無交易記錄
             </Card>

--- a/frontend/src/router.tsx
+++ b/frontend/src/router.tsx
@@ -10,6 +10,7 @@ import AccountList from '@/pages/accounts/AccountList';
 import NotFound from '@/pages/NotFound';
 import AssetList from '@/pages/assets/AssetList';
 import AssetHistoryPage from '@/pages/assets/AssetHistoryPage';
+import StatisticsPage from '@/pages/statistics/StatisticsPage';
 
 // 受保護路由組件
 const PrivateRoute = ({ children }: { children: React.ReactNode }) => {
@@ -74,6 +75,10 @@ export const router = createBrowserRouter([
       {
         path: 'history',
         element: <AssetHistoryPage />,
+      },
+      {
+        path: 'statistics',
+        element: <StatisticsPage />,
       },
     ],
   },


### PR DESCRIPTION
## Summary
- Dashboard 改為串接真實 API（月度統計、帳戶餘額加總、帳戶數量），移除所有 hardcode 數字
- 新增 StatisticsPage：月份選擇器、收入/支出/結餘摘要卡片、圓餅圖（Recharts）、類別明細表格
- 新增 `/statistics` 路由
- 移除側邊欄「統計分析」的 `disabled: true`

## Test plan
- [x] Dashboard 登入後顯示真實數字（本月收支、帳戶餘額、帳戶數量）
- [x] 無資料時顯示 0，不報錯
- [x] 統計分析頁面可從側邊欄點擊進入
- [x] 月份切換後資料隨之更新
- [x] 有交易記錄的月份顯示圓餅圖；無記錄顯示「本月尚無交易記錄」

🤖 Generated with [Claude Code](https://claude.com/claude-code)