### PR TITLE
feat(auth): auto-create default categories and accounts on registration

### DIFF
--- a/backend/src/main/java/com/pocketfolio/backend/service/AuthService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/AuthService.java
@@ -3,7 +3,13 @@ package com.pocketfolio.backend.service;
 import com.pocketfolio.backend.dto.AuthResponse;
 import com.pocketfolio.backend.dto.LoginRequest;
 import com.pocketfolio.backend.dto.RegisterRequest;
+import com.pocketfolio.backend.entity.Account;
+import com.pocketfolio.backend.entity.AccountType;
+import com.pocketfolio.backend.entity.Category;
+import com.pocketfolio.backend.entity.CategoryType;
 import com.pocketfolio.backend.entity.User;
+import com.pocketfolio.backend.repository.AccountRepository;
+import com.pocketfolio.backend.repository.CategoryRepository;
 import com.pocketfolio.backend.repository.UserRepository;
 import com.pocketfolio.backend.security.JwtUtil;
 import lombok.RequiredArgsConstructor;
@@ -13,13 +19,17 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class AuthService {
 
     private final UserRepository userRepository;
+    private final CategoryRepository categoryRepository;
+    private final AccountRepository accountRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtUtil jwtUtil;
     private final AuthenticationManager authenticationManager;
@@ -46,6 +56,45 @@ public class AuthService {
         user.setCreatedAt(LocalDateTime.now());
 
         User savedUser = userRepository.save(user);
+
+        // 建立預設類別
+        List<String> expenseNames = List.of("餐飲", "交通", "娛樂", "購物", "住房", "醫療", "教育");
+        List<String> incomeNames = List.of("薪資", "獎金", "投資收益", "其他收入");
+        List<Category> defaultCategories = new java.util.ArrayList<>();
+        for (String name : expenseNames) {
+            Category c = new Category();
+            c.setName(name);
+            c.setType(CategoryType.EXPENSE);
+            c.setUser(savedUser);
+            defaultCategories.add(c);
+        }
+        for (String name : incomeNames) {
+            Category c = new Category();
+            c.setName(name);
+            c.setType(CategoryType.INCOME);
+            c.setUser(savedUser);
+            defaultCategories.add(c);
+        }
+        categoryRepository.saveAll(defaultCategories);
+
+        // 建立預設帳戶
+        record DefaultAccount(String name, AccountType type) {}
+        List<DefaultAccount> defaultAccountDefs = List.of(
+                new DefaultAccount("現金", AccountType.CASH),
+                new DefaultAccount("銀行帳戶", AccountType.BANK),
+                new DefaultAccount("信用卡", AccountType.CREDIT_CARD),
+                new DefaultAccount("投資帳戶", AccountType.INVESTMENT)
+        );
+        List<Account> defaultAccounts = new java.util.ArrayList<>();
+        for (DefaultAccount def : defaultAccountDefs) {
+            Account a = new Account();
+            a.setName(def.name());
+            a.setType(def.type());
+            a.setInitialBalance(BigDecimal.ZERO);
+            a.setUser(savedUser);
+            defaultAccounts.add(a);
+        }
+        accountRepository.saveAll(defaultAccounts);
 
         // 產生 JWT Token
         String token = jwtUtil.generateToken(savedUser);


### PR DESCRIPTION
## Summary
- 新用戶註冊後自動建立 7 個預設支出類別（餐飲、交通、娛樂、購物、住房、醫療、教育）
- 自動建立 4 個預設收入類別（薪資、獎金、投資收益、其他收入）
- 自動建立 4 個預設帳戶（現金、銀行帳戶、信用卡、投資帳戶，初始餘額皆為 0）

## Changes
- `AuthService.register()`: 在 `userRepository.save()` 後，用 `saveAll()` 批次建立預設資料
- 注入 `CategoryRepository` 與 `AccountRepository`（Lombok `@RequiredArgsConstructor` 自動處理）

## Test plan
- [x] 用新 email 註冊，登入後到類別頁確認 11 個預設類別存在
- [x] 確認帳戶頁有 4 個預設帳戶，初始餘額皆為 0
- [x] 確認已存在用戶的資料不受影響

🤖 Generated with [Claude Code](https://claude.com/claude-code)