### PR TITLE
feat(assets): asset search autocomplete with TWSE/TPEX/CoinGecko sync

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -125,6 +125,16 @@
             <artifactId>postgres-socket-factory</artifactId>
             <version>1.22.0</version>
         </dependency>
+
+        <!-- Spring Retry（同步外部 API 失敗時自動重試）-->
+        <dependency>
+            <groupId>org.springframework.retry</groupId>
+            <artifactId>spring-retry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aspects</artifactId>
+        </dependency>
 	</dependencies>
 
 	<build>

--- a/backend/src/main/java/com/pocketfolio/backend/BackendApplication.java
+++ b/backend/src/main/java/com/pocketfolio/backend/BackendApplication.java
@@ -2,8 +2,12 @@ package com.pocketfolio.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.retry.annotation.EnableRetry;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableRetry
+@EnableScheduling
 public class BackendApplication {
 
 	public static void main(String[] args) {

--- a/backend/src/main/java/com/pocketfolio/backend/controller/KnownAssetController.java
+++ b/backend/src/main/java/com/pocketfolio/backend/controller/KnownAssetController.java
@@ -1,0 +1,39 @@
+package com.pocketfolio.backend.controller;
+
+import com.pocketfolio.backend.dto.KnownAssetResponse;
+import com.pocketfolio.backend.repository.KnownAssetRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/known-assets")
+@RequiredArgsConstructor
+@Tag(name = "7. 資產搜尋", description = "搜尋已知股票與加密貨幣清單（Autocomplete 用）")
+@SecurityRequirement(name = "bearerAuth")
+public class KnownAssetController {
+
+    private final KnownAssetRepository knownAssetRepository;
+
+    @GetMapping("/search")
+    @Operation(
+            summary = "搜尋資產",
+            description = "依關鍵字搜尋資產代碼或名稱，回傳最多 20 筆。assetType: STOCK_TW / STOCK_TWO / CRYPTO"
+    )
+    public List<KnownAssetResponse> search(
+            @RequestParam String assetType,
+            @RequestParam String keyword) {
+
+        return knownAssetRepository.searchByKeyword(assetType, keyword)
+                .stream()
+                .map(KnownAssetResponse::from)
+                .toList();
+    }
+}

--- a/backend/src/main/java/com/pocketfolio/backend/controller/KnownAssetController.java
+++ b/backend/src/main/java/com/pocketfolio/backend/controller/KnownAssetController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -31,7 +32,7 @@ public class KnownAssetController {
             @RequestParam String assetType,
             @RequestParam String keyword) {
 
-        return knownAssetRepository.searchByKeyword(assetType, keyword)
+        return knownAssetRepository.searchByKeyword(assetType, keyword, PageRequest.of(0, 20))
                 .stream()
                 .map(KnownAssetResponse::from)
                 .toList();

--- a/backend/src/main/java/com/pocketfolio/backend/dto/KnownAssetResponse.java
+++ b/backend/src/main/java/com/pocketfolio/backend/dto/KnownAssetResponse.java
@@ -1,0 +1,24 @@
+package com.pocketfolio.backend.dto;
+
+import com.pocketfolio.backend.entity.KnownAsset;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class KnownAssetResponse {
+
+    private String symbol;
+    private String name;
+    private String displayCode;
+    private String assetType;
+
+    public static KnownAssetResponse from(KnownAsset ka) {
+        return KnownAssetResponse.builder()
+                .symbol(ka.getSymbol())
+                .name(ka.getName())
+                .displayCode(ka.getDisplayCode())
+                .assetType(ka.getAssetType())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/pocketfolio/backend/dto/KnownAssetResponse.java
+++ b/backend/src/main/java/com/pocketfolio/backend/dto/KnownAssetResponse.java
@@ -12,6 +12,7 @@ public class KnownAssetResponse {
     private String name;
     private String displayCode;
     private String assetType;
+    private Integer marketCapRank;
 
     public static KnownAssetResponse from(KnownAsset ka) {
         return KnownAssetResponse.builder()
@@ -19,6 +20,7 @@ public class KnownAssetResponse {
                 .name(ka.getName())
                 .displayCode(ka.getDisplayCode())
                 .assetType(ka.getAssetType())
+                .marketCapRank(ka.getMarketCapRank())
                 .build();
     }
 }

--- a/backend/src/main/java/com/pocketfolio/backend/entity/KnownAsset.java
+++ b/backend/src/main/java/com/pocketfolio/backend/entity/KnownAsset.java
@@ -25,14 +25,14 @@ public class KnownAsset {
 
     // Yahoo Finance / CoinGecko API 相容代號
     // 台股上市：2330.TW，上櫃：6547.TWO，加密：bitcoin（CoinGecko id）
-    @Column(nullable = false, unique = true, length = 30)
+    @Column(nullable = false, unique = true, length = 100)
     private String symbol;
 
     // 顯示名稱：台積電、Bitcoin
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, length = 200)
     private String name;
 
     // 用戶看到的短代碼：2330、BTC（搜尋用）
-    @Column(name = "display_code", nullable = false, length = 20)
+    @Column(name = "display_code", nullable = false, length = 50)
     private String displayCode;
 }

--- a/backend/src/main/java/com/pocketfolio/backend/entity/KnownAsset.java
+++ b/backend/src/main/java/com/pocketfolio/backend/entity/KnownAsset.java
@@ -1,0 +1,38 @@
+package com.pocketfolio.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "known_assets", indexes = {
+        @Index(name = "idx_known_assets_symbol", columnList = "symbol"),
+        @Index(name = "idx_known_assets_asset_type", columnList = "asset_type")
+})
+@Getter
+@Setter
+public class KnownAsset {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    // 資產類型：STOCK / CRYPTO
+    @Column(name = "asset_type", nullable = false, length = 10)
+    private String assetType;
+
+    // Yahoo Finance / CoinGecko API 相容代號
+    // 台股上市：2330.TW，上櫃：6547.TWO，加密：bitcoin（CoinGecko id）
+    @Column(nullable = false, unique = true, length = 30)
+    private String symbol;
+
+    // 顯示名稱：台積電、Bitcoin
+    @Column(nullable = false, length = 100)
+    private String name;
+
+    // 用戶看到的短代碼：2330、BTC（搜尋用）
+    @Column(name = "display_code", nullable = false, length = 20)
+    private String displayCode;
+}

--- a/backend/src/main/java/com/pocketfolio/backend/entity/KnownAsset.java
+++ b/backend/src/main/java/com/pocketfolio/backend/entity/KnownAsset.java
@@ -35,4 +35,8 @@ public class KnownAsset {
     // 用戶看到的短代碼：2330、BTC（搜尋用）
     @Column(name = "display_code", nullable = false, length = 50)
     private String displayCode;
+
+    // CoinGecko 市值排名（前 1000 名才有值，其餘為 null）；搜尋結果排序依據
+    @Column(name = "market_cap_rank")
+    private Integer marketCapRank;
 }

--- a/backend/src/main/java/com/pocketfolio/backend/repository/KnownAssetRepository.java
+++ b/backend/src/main/java/com/pocketfolio/backend/repository/KnownAssetRepository.java
@@ -1,6 +1,7 @@
 package com.pocketfolio.backend.repository;
 
 import com.pocketfolio.backend.entity.KnownAsset;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -12,17 +13,17 @@ public interface KnownAssetRepository extends JpaRepository<KnownAsset, UUID> {
 
     boolean existsBySymbol(String symbol);
 
-    // 搜尋名稱或顯示代碼，限制回傳筆數避免 response 過大
+    // 搜尋名稱或顯示代碼，筆數限制由 Pageable 控制（避免 JPQL LIMIT 相容性問題）
     @Query("""
             SELECT k FROM KnownAsset k
             WHERE k.assetType = :assetType
               AND (LOWER(k.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
                 OR LOWER(k.displayCode) LIKE LOWER(CONCAT('%', :keyword, '%')))
             ORDER BY k.displayCode
-            LIMIT 20
             """)
     List<KnownAsset> searchByKeyword(@Param("assetType") String assetType,
-                                     @Param("keyword") String keyword);
+                                     @Param("keyword") String keyword,
+                                     Pageable pageable);
 
     long countByAssetType(String assetType);
 

--- a/backend/src/main/java/com/pocketfolio/backend/repository/KnownAssetRepository.java
+++ b/backend/src/main/java/com/pocketfolio/backend/repository/KnownAssetRepository.java
@@ -1,0 +1,30 @@
+package com.pocketfolio.backend.repository;
+
+import com.pocketfolio.backend.entity.KnownAsset;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface KnownAssetRepository extends JpaRepository<KnownAsset, UUID> {
+
+    boolean existsBySymbol(String symbol);
+
+    // 搜尋名稱或顯示代碼，限制回傳筆數避免 response 過大
+    @Query("""
+            SELECT k FROM KnownAsset k
+            WHERE k.assetType = :assetType
+              AND (LOWER(k.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
+                OR LOWER(k.displayCode) LIKE LOWER(CONCAT('%', :keyword, '%')))
+            ORDER BY k.displayCode
+            LIMIT 20
+            """)
+    List<KnownAsset> searchByKeyword(@Param("assetType") String assetType,
+                                     @Param("keyword") String keyword);
+
+    long countByAssetType(String assetType);
+
+    void deleteByAssetType(String assetType);
+}

--- a/backend/src/main/java/com/pocketfolio/backend/repository/KnownAssetRepository.java
+++ b/backend/src/main/java/com/pocketfolio/backend/repository/KnownAssetRepository.java
@@ -13,13 +13,13 @@ public interface KnownAssetRepository extends JpaRepository<KnownAsset, UUID> {
 
     boolean existsBySymbol(String symbol);
 
-    // 搜尋名稱或顯示代碼，筆數限制由 Pageable 控制（避免 JPQL LIMIT 相容性問題）
+    // 搜尋名稱或顯示代碼，市值排名小的優先（垃圾幣排後面），無排名的排最後
     @Query("""
             SELECT k FROM KnownAsset k
             WHERE k.assetType = :assetType
               AND (LOWER(k.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
                 OR LOWER(k.displayCode) LIKE LOWER(CONCAT('%', :keyword, '%')))
-            ORDER BY k.displayCode
+            ORDER BY k.marketCapRank ASC NULLS LAST, k.displayCode ASC
             """)
     List<KnownAsset> searchByKeyword(@Param("assetType") String assetType,
                                      @Param("keyword") String keyword,

--- a/backend/src/main/java/com/pocketfolio/backend/scheduler/KnownAssetSyncScheduler.java
+++ b/backend/src/main/java/com/pocketfolio/backend/scheduler/KnownAssetSyncScheduler.java
@@ -40,12 +40,25 @@ public class KnownAssetSyncScheduler {
 
     /**
      * 每天凌晨 2 點執行全量同步。
-     * 台股收盤後新增或下市的清單會在隔日更新。
+     * 直接呼叫 syncService 的各個方法（經過 Spring proxy），確保 @Retryable 和 @Transactional 正常生效。
+     * 不可改成 syncService.syncAll() 內部 this:: 呼叫，否則會繞過 AOP proxy（self-invocation 問題）。
      */
     @Scheduled(cron = "0 0 2 * * *")
     public void dailySync() {
         log.info("=== 定時任務開始：同步資產清單 ===");
-        syncService.syncAll();
+        syncSafe("TWSE", syncService::syncTwse);
+        syncSafe("TPEX", syncService::syncTpex);
+        syncSafe("CoinGecko", syncService::syncCrypto);
         log.info("=== 定時任務完成：資產清單同步 ===");
+    }
+
+    // retry 耗盡後 log error，不讓例外往上傳中斷排程
+    private void syncSafe(String source, java.util.function.IntSupplier syncFn) {
+        try {
+            int count = syncFn.getAsInt();
+            log.info("{} 同步完成：{} 筆", source, count);
+        } catch (Exception e) {
+            log.error("{} 同步最終失敗（已重試 3 次）：{}", source, e.getMessage());
+        }
     }
 }

--- a/backend/src/main/java/com/pocketfolio/backend/scheduler/KnownAssetSyncScheduler.java
+++ b/backend/src/main/java/com/pocketfolio/backend/scheduler/KnownAssetSyncScheduler.java
@@ -1,0 +1,45 @@
+package com.pocketfolio.backend.scheduler;
+
+import com.pocketfolio.backend.repository.KnownAssetRepository;
+import com.pocketfolio.backend.service.KnownAssetSyncService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class KnownAssetSyncScheduler {
+
+    private final KnownAssetSyncService syncService;
+    private final KnownAssetRepository knownAssetRepository;
+
+    /**
+     * 應用程式啟動後執行一次初始化同步。
+     * 若 DB 已有資料（重啟時），跳過以節省 API 呼叫。
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void initOnStartup() {
+        long count = knownAssetRepository.count();
+        if (count > 0) {
+            log.info("known_assets 表已有 {} 筆資料，跳過啟動初始化同步", count);
+            return;
+        }
+        log.info("known_assets 表為空，執行首次同步...");
+        syncService.syncAll();
+    }
+
+    /**
+     * 每天凌晨 2 點執行全量同步。
+     * 台股收盤後新增或下市的清單會在隔日更新。
+     */
+    @Scheduled(cron = "0 0 2 * * *")
+    public void dailySync() {
+        log.info("=== 定時任務開始：同步資產清單 ===");
+        syncService.syncAll();
+        log.info("=== 定時任務完成：資產清單同步 ===");
+    }
+}

--- a/backend/src/main/java/com/pocketfolio/backend/scheduler/KnownAssetSyncScheduler.java
+++ b/backend/src/main/java/com/pocketfolio/backend/scheduler/KnownAssetSyncScheduler.java
@@ -23,13 +23,19 @@ public class KnownAssetSyncScheduler {
      */
     @EventListener(ApplicationReadyEvent.class)
     public void initOnStartup() {
-        long count = knownAssetRepository.count();
-        if (count > 0) {
-            log.info("known_assets 表已有 {} 筆資料，跳過啟動初始化同步", count);
-            return;
+        // 分別檢查每個類型，確保各類型都有資料（避免部分同步後重啟跳過剩餘類型）
+        if (knownAssetRepository.countByAssetType("STOCK_TW") == 0) {
+            log.info("STOCK_TW 為空，執行同步...");
+            syncService.syncTwse();
         }
-        log.info("known_assets 表為空，執行首次同步...");
-        syncService.syncAll();
+        if (knownAssetRepository.countByAssetType("STOCK_TWO") == 0) {
+            log.info("STOCK_TWO 為空，執行同步...");
+            syncService.syncTpex();
+        }
+        if (knownAssetRepository.countByAssetType("CRYPTO") == 0) {
+            log.info("CRYPTO 為空，執行同步...");
+            syncService.syncCrypto();
+        }
     }
 
     /**

--- a/backend/src/main/java/com/pocketfolio/backend/service/KnownAssetSyncService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/KnownAssetSyncService.java
@@ -1,0 +1,196 @@
+package com.pocketfolio.backend.service;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.pocketfolio.backend.entity.KnownAsset;
+import com.pocketfolio.backend.repository.KnownAssetRepository;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KnownAssetSyncService {
+
+    private final KnownAssetRepository knownAssetRepository;
+    private final WebClient.Builder webClientBuilder;
+
+    @Value("${api.coingecko.base-url}")
+    private String coinGeckoBaseUrl;
+
+    private static final String TWSE_URL =
+            "https://openapi.twse.com.tw/v1/exchangeReport/STOCK_DAY_ALL";
+    private static final String TPEX_URL =
+            "https://www.tpex.org.tw/openapi/v1/tpex_mainboard_quotes";
+
+    // 最低合理筆數（低於此值視為 API 異常，拒絕寫入）
+    private static final int TWSE_MIN_COUNT = 500;
+    private static final int TPEX_MIN_COUNT = 400;
+    private static final int CRYPTO_MIN_COUNT = 5000;
+
+    // ────────────── TWSE 上市（含 ETF） ──────────────
+
+    @Transactional
+    public int syncTwse() {
+        log.info("開始同步 TWSE 上市股票與 ETF...");
+        try {
+            List<TwseItem> items = webClientBuilder.build()
+                    .get().uri(TWSE_URL)
+                    .retrieve()
+                    .bodyToFlux(TwseItem.class)
+                    .collectList()
+                    .block();
+
+            if (items == null || items.size() < TWSE_MIN_COUNT) {
+                log.warn("TWSE 回傳資料量異常（{}筆），跳過本次同步", items == null ? 0 : items.size());
+                return 0;
+            }
+
+            List<KnownAsset> toSave = new ArrayList<>();
+            for (TwseItem item : items) {
+                if (item.getCode() == null || item.getName() == null) continue;
+                KnownAsset ka = new KnownAsset();
+                ka.setAssetType("STOCK_TW");
+                ka.setSymbol(item.getCode() + ".TW");
+                ka.setDisplayCode(item.getCode());
+                ka.setName(item.getName());
+                toSave.add(ka);
+            }
+
+            // delete + saveAll 在同一個 @Transactional，任一失敗則全部 rollback
+            knownAssetRepository.deleteByAssetType("STOCK_TW");
+            knownAssetRepository.saveAll(toSave);
+            log.info("TWSE 同步完成：{} 筆", toSave.size());
+            return toSave.size();
+
+        } catch (Exception e) {
+            log.error("TWSE 同步失敗：{}", e.getMessage(), e);
+            return 0;
+        }
+    }
+
+    // ────────────── TPEX 上櫃（含 ETF） ──────────────
+
+    @Transactional
+    public int syncTpex() {
+        log.info("開始同步 TPEX 上櫃股票與 ETF...");
+        try {
+            List<TpexItem> items = webClientBuilder.build()
+                    .get().uri(TPEX_URL)
+                    .retrieve()
+                    .bodyToFlux(TpexItem.class)
+                    .collectList()
+                    .block();
+
+            if (items == null || items.size() < TPEX_MIN_COUNT) {
+                log.warn("TPEX 回傳資料量異常（{}筆），跳過本次同步", items == null ? 0 : items.size());
+                return 0;
+            }
+
+            List<KnownAsset> toSave = new ArrayList<>();
+            for (TpexItem item : items) {
+                if (item.getCode() == null || item.getName() == null) continue;
+                KnownAsset ka = new KnownAsset();
+                ka.setAssetType("STOCK_TWO");
+                ka.setSymbol(item.getCode() + ".TWO");
+                ka.setDisplayCode(item.getCode());
+                ka.setName(item.getName());
+                toSave.add(ka);
+            }
+
+            knownAssetRepository.deleteByAssetType("STOCK_TWO");
+            knownAssetRepository.saveAll(toSave);
+            log.info("TPEX 同步完成：{} 筆", toSave.size());
+            return toSave.size();
+
+        } catch (Exception e) {
+            log.error("TPEX 同步失敗：{}", e.getMessage(), e);
+            return 0;
+        }
+    }
+
+    // ────────────── CoinGecko 加密貨幣 ──────────────
+
+    @Transactional
+    public int syncCrypto() {
+        log.info("開始同步 CoinGecko 加密貨幣清單...");
+        try {
+            List<CoinGeckoListItem> items = webClientBuilder.baseUrl(coinGeckoBaseUrl).build()
+                    .get().uri("/coins/list")
+                    .retrieve()
+                    .bodyToFlux(CoinGeckoListItem.class)
+                    .collectList()
+                    .block();
+
+            if (items == null || items.size() < CRYPTO_MIN_COUNT) {
+                log.warn("CoinGecko 回傳資料量異常（{}筆），跳過本次同步", items == null ? 0 : items.size());
+                return 0;
+            }
+
+            List<KnownAsset> toSave = new ArrayList<>();
+            for (CoinGeckoListItem item : items) {
+                if (item.getId() == null || item.getSymbol() == null || item.getName() == null) continue;
+                KnownAsset ka = new KnownAsset();
+                ka.setAssetType("CRYPTO");
+                ka.setSymbol(item.getId());                         // CoinGecko id，例如 "bitcoin"
+                ka.setDisplayCode(item.getSymbol().toUpperCase());  // 例如 "BTC"
+                ka.setName(item.getName());                         // 例如 "Bitcoin"
+                toSave.add(ka);
+            }
+
+            knownAssetRepository.deleteByAssetType("CRYPTO");
+            knownAssetRepository.saveAll(toSave);
+            log.info("CoinGecko 同步完成：{} 筆", toSave.size());
+            return toSave.size();
+
+        } catch (Exception e) {
+            log.error("CoinGecko 同步失敗：{}", e.getMessage(), e);
+            return 0;
+        }
+    }
+
+    // ────────────── 全部同步 ──────────────
+
+    public void syncAll() {
+        int twse = syncTwse();
+        int tpex = syncTpex();
+        int crypto = syncCrypto();
+        log.info("資產清單全量同步完成 — TWSE: {}, TPEX: {}, Crypto: {}", twse, tpex, crypto);
+    }
+
+    // ────────────── 內部 DTO ──────────────
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class TwseItem {
+        @JsonProperty("Code")
+        private String code;
+        @JsonProperty("Name")
+        private String name;
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class TpexItem {
+        @JsonProperty("SecuritiesCompanyCode")
+        private String code;
+        @JsonProperty("CompanyName")
+        private String name;
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class CoinGeckoListItem {
+        private String id;
+        private String symbol;
+        private String name;
+    }
+}

--- a/backend/src/main/java/com/pocketfolio/backend/service/KnownAssetSyncService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/KnownAssetSyncService.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.ArrayList;
@@ -123,7 +124,13 @@ public class KnownAssetSyncService {
     public int syncCrypto() {
         log.info("開始同步 CoinGecko 加密貨幣清單...");
         try {
-            List<CoinGeckoListItem> items = webClientBuilder.baseUrl(coinGeckoBaseUrl).build()
+            // CoinGecko /coins/list 回應約 1MB，超過 WebClient 預設 256KB buffer，需明確指定上限
+            ExchangeStrategies strategies = ExchangeStrategies.builder()
+                    .codecs(config -> config.defaultCodecs().maxInMemorySize(5 * 1024 * 1024)) // 5MB
+                    .build();
+            List<CoinGeckoListItem> items = webClientBuilder.baseUrl(coinGeckoBaseUrl)
+                    .exchangeStrategies(strategies)
+                    .build()
                     .get().uri("/coins/list")
                     .retrieve()
                     .bodyToFlux(CoinGeckoListItem.class)

--- a/backend/src/main/java/com/pocketfolio/backend/service/KnownAssetSyncService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/KnownAssetSyncService.java
@@ -12,7 +12,6 @@ import org.springframework.retry.annotation.Backoff;
 import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.ArrayList;
@@ -37,7 +36,7 @@ public class KnownAssetSyncService {
     // 最低合理筆數（低於此值視為 API 異常，拒絕寫入）
     private static final int TWSE_MIN_COUNT = 500;
     private static final int TPEX_MIN_COUNT = 400;
-    private static final int CRYPTO_MIN_COUNT = 5000;
+    private static final int CRYPTO_MIN_COUNT = 150;
 
     // ────────────── TWSE 上市（含 ETF） ──────────────
 
@@ -114,60 +113,24 @@ public class KnownAssetSyncService {
     // ────────────── CoinGecko 加密貨幣 ──────────────
 
     /**
-     * 從 /coins/markets 抓前 1000 名的市值排名（每頁 250 筆，共 4 頁）。
-     * 免費 API rate limit 約 30 req/min，4 頁之間各 sleep 2s。
+     * 從 /coins/markets 抓市值前 200 名的加密貨幣。
+     * 只同步有實際交易的主流幣，避免廢棄幣污染搜尋結果。
      */
-    private java.util.Map<String, Integer> fetchMarketCapRanks() {
-        java.util.Map<String, Integer> rankMap = new java.util.HashMap<>();
-        WebClient client = webClientBuilder.baseUrl(coinGeckoBaseUrl).build();
-        for (int page = 1; page <= 4; page++) {
-            try {
-                int p = page;
-                List<CoinGeckoMarketItem> pageItems = client.get()
-                        .uri(u -> u.path("/coins/markets")
-                                .queryParam("vs_currency", "usd")
-                                .queryParam("order", "market_cap_desc")
-                                .queryParam("per_page", 250)
-                                .queryParam("page", p)
-                                .build())
-                        .retrieve()
-                        .bodyToFlux(CoinGeckoMarketItem.class)
-                        .collectList()
-                        .block();
-                if (pageItems != null) {
-                    pageItems.forEach(item -> {
-                        if (item.getId() != null && item.getMarketCapRank() != null) {
-                            rankMap.put(item.getId(), item.getMarketCapRank());
-                        }
-                    });
-                }
-                if (page < 4) Thread.sleep(2000); // 避免 rate limit
-            } catch (Exception e) {
-                log.warn("fetchMarketCapRanks page {} 失敗，繼續其餘頁: {}", page, e.getMessage());
-            }
-        }
-        log.info("市值排名同步完成：{} 筆", rankMap.size());
-        return rankMap;
-    }
-
     @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 2000, multiplier = 2))
     @Transactional
     public int syncCrypto() {
-        log.info("開始同步 CoinGecko 加密貨幣清單...");
+        log.info("開始同步 CoinGecko 市值前 200 加密貨幣...");
 
-        // 先取得前 1000 名市值排名
-        java.util.Map<String, Integer> rankMap = fetchMarketCapRanks();
-
-        // CoinGecko /coins/list 回應約 1MB，超過 WebClient 預設 256KB buffer，需明確指定上限
-        ExchangeStrategies strategies = ExchangeStrategies.builder()
-                .codecs(config -> config.defaultCodecs().maxInMemorySize(5 * 1024 * 1024)) // 5MB
-                .build();
-        List<CoinGeckoListItem> items = webClientBuilder.baseUrl(coinGeckoBaseUrl)
-                .exchangeStrategies(strategies)
-                .build()
-                .get().uri("/coins/list")
+        List<CoinGeckoMarketItem> items = webClientBuilder.baseUrl(coinGeckoBaseUrl).build()
+                .get()
+                .uri(u -> u.path("/coins/markets")
+                        .queryParam("vs_currency", "usd")
+                        .queryParam("order", "market_cap_desc")
+                        .queryParam("per_page", 200)
+                        .queryParam("page", 1)
+                        .build())
                 .retrieve()
-                .bodyToFlux(CoinGeckoListItem.class)
+                .bodyToFlux(CoinGeckoMarketItem.class)
                 .collectList()
                 .block();
 
@@ -177,14 +140,14 @@ public class KnownAssetSyncService {
         }
 
         List<KnownAsset> toSave = new ArrayList<>();
-        for (CoinGeckoListItem item : items) {
+        for (CoinGeckoMarketItem item : items) {
             if (item.getId() == null || item.getSymbol() == null || item.getName() == null) continue;
             KnownAsset ka = new KnownAsset();
             ka.setAssetType("CRYPTO");
             ka.setSymbol(item.getId());                         // CoinGecko id，例如 "bitcoin"
             ka.setDisplayCode(item.getSymbol().toUpperCase());  // 例如 "BTC"
             ka.setName(item.getName());                         // 例如 "Bitcoin"
-            ka.setMarketCapRank(rankMap.get(item.getId()));     // 前 1000 名有值，其餘 null
+            ka.setMarketCapRank(item.getMarketCapRank());
             toSave.add(ka);
         }
 
@@ -216,16 +179,10 @@ public class KnownAssetSyncService {
 
     @Data
     @JsonIgnoreProperties(ignoreUnknown = true)
-    static class CoinGeckoListItem {
+    static class CoinGeckoMarketItem {
         private String id;
         private String symbol;
         private String name;
-    }
-
-    @Data
-    @JsonIgnoreProperties(ignoreUnknown = true)
-    static class CoinGeckoMarketItem {
-        private String id;
         @JsonProperty("market_cap_rank")
         private Integer marketCapRank;
     }

--- a/backend/src/main/java/com/pocketfolio/backend/service/KnownAssetSyncService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/KnownAssetSyncService.java
@@ -194,25 +194,6 @@ public class KnownAssetSyncService {
         return toSave.size();
     }
 
-    // ────────────── 全部同步 ──────────────
-
-    public void syncAll() {
-        int twse = syncSafe("TWSE", this::syncTwse);
-        int tpex = syncSafe("TPEX", this::syncTpex);
-        int crypto = syncSafe("CoinGecko", this::syncCrypto);
-        log.info("資產清單全量同步完成 — TWSE: {}, TPEX: {}, Crypto: {}", twse, tpex, crypto);
-    }
-
-    // 包裝每個 sync 方法：3 次 retry 都失敗後記錄 error，不讓例外往上傳讓 scheduler 中斷
-    private int syncSafe(String source, java.util.function.IntSupplier syncFn) {
-        try {
-            return syncFn.getAsInt();
-        } catch (Exception e) {
-            log.error("{} 同步最終失敗（已重試 3 次）：{}", source, e.getMessage());
-            return 0;
-        }
-    }
-
     // ────────────── 內部 DTO ──────────────
 
     @Data

--- a/backend/src/main/java/com/pocketfolio/backend/service/KnownAssetSyncService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/KnownAssetSyncService.java
@@ -8,6 +8,8 @@ import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.reactive.function.client.ExchangeStrategies;
@@ -39,138 +41,176 @@ public class KnownAssetSyncService {
 
     // ────────────── TWSE 上市（含 ETF） ──────────────
 
+    // 網路或 API 例外時自動重試（2s → 4s → 8s）；sanity check 回傳 0 不觸發 retry
+    @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 2000, multiplier = 2))
     @Transactional
     public int syncTwse() {
         log.info("開始同步 TWSE 上市股票與 ETF...");
-        try {
-            List<TwseItem> items = webClientBuilder.build()
-                    .get().uri(TWSE_URL)
-                    .retrieve()
-                    .bodyToFlux(TwseItem.class)
-                    .collectList()
-                    .block();
+        List<TwseItem> items = webClientBuilder.build()
+                .get().uri(TWSE_URL)
+                .retrieve()
+                .bodyToFlux(TwseItem.class)
+                .collectList()
+                .block();
 
-            if (items == null || items.size() < TWSE_MIN_COUNT) {
-                log.warn("TWSE 回傳資料量異常（{}筆），跳過本次同步", items == null ? 0 : items.size());
-                return 0;
-            }
-
-            List<KnownAsset> toSave = new ArrayList<>();
-            for (TwseItem item : items) {
-                if (item.getCode() == null || item.getName() == null) continue;
-                KnownAsset ka = new KnownAsset();
-                ka.setAssetType("STOCK_TW");
-                ka.setSymbol(item.getCode() + ".TW");
-                ka.setDisplayCode(item.getCode());
-                ka.setName(item.getName());
-                toSave.add(ka);
-            }
-
-            // delete + saveAll 在同一個 @Transactional，任一失敗則全部 rollback
-            knownAssetRepository.deleteByAssetType("STOCK_TW");
-            knownAssetRepository.saveAll(toSave);
-            log.info("TWSE 同步完成：{} 筆", toSave.size());
-            return toSave.size();
-
-        } catch (Exception e) {
-            log.error("TWSE 同步失敗：{}", e.getMessage(), e);
+        if (items == null || items.size() < TWSE_MIN_COUNT) {
+            log.warn("TWSE 回傳資料量異常（{}筆），跳過本次同步", items == null ? 0 : items.size());
             return 0;
         }
+
+        List<KnownAsset> toSave = new ArrayList<>();
+        for (TwseItem item : items) {
+            if (item.getCode() == null || item.getName() == null) continue;
+            KnownAsset ka = new KnownAsset();
+            ka.setAssetType("STOCK_TW");
+            ka.setSymbol(item.getCode() + ".TW");
+            ka.setDisplayCode(item.getCode());
+            ka.setName(item.getName());
+            toSave.add(ka);
+        }
+
+        // delete + saveAll 在同一個 @Transactional，任一失敗則全部 rollback
+        knownAssetRepository.deleteByAssetType("STOCK_TW");
+        knownAssetRepository.saveAll(toSave);
+        log.info("TWSE 同步完成：{} 筆", toSave.size());
+        return toSave.size();
     }
 
     // ────────────── TPEX 上櫃（含 ETF） ──────────────
 
+    @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 2000, multiplier = 2))
     @Transactional
     public int syncTpex() {
         log.info("開始同步 TPEX 上櫃股票與 ETF...");
-        try {
-            List<TpexItem> items = webClientBuilder.build()
-                    .get().uri(TPEX_URL)
-                    .retrieve()
-                    .bodyToFlux(TpexItem.class)
-                    .collectList()
-                    .block();
+        List<TpexItem> items = webClientBuilder.build()
+                .get().uri(TPEX_URL)
+                .retrieve()
+                .bodyToFlux(TpexItem.class)
+                .collectList()
+                .block();
 
-            if (items == null || items.size() < TPEX_MIN_COUNT) {
-                log.warn("TPEX 回傳資料量異常（{}筆），跳過本次同步", items == null ? 0 : items.size());
-                return 0;
-            }
-
-            List<KnownAsset> toSave = new ArrayList<>();
-            for (TpexItem item : items) {
-                if (item.getCode() == null || item.getName() == null) continue;
-                KnownAsset ka = new KnownAsset();
-                ka.setAssetType("STOCK_TWO");
-                ka.setSymbol(item.getCode() + ".TWO");
-                ka.setDisplayCode(item.getCode());
-                ka.setName(item.getName());
-                toSave.add(ka);
-            }
-
-            knownAssetRepository.deleteByAssetType("STOCK_TWO");
-            knownAssetRepository.saveAll(toSave);
-            log.info("TPEX 同步完成：{} 筆", toSave.size());
-            return toSave.size();
-
-        } catch (Exception e) {
-            log.error("TPEX 同步失敗：{}", e.getMessage(), e);
+        if (items == null || items.size() < TPEX_MIN_COUNT) {
+            log.warn("TPEX 回傳資料量異常（{}筆），跳過本次同步", items == null ? 0 : items.size());
             return 0;
         }
+
+        List<KnownAsset> toSave = new ArrayList<>();
+        for (TpexItem item : items) {
+            if (item.getCode() == null || item.getName() == null) continue;
+            KnownAsset ka = new KnownAsset();
+            ka.setAssetType("STOCK_TWO");
+            ka.setSymbol(item.getCode() + ".TWO");
+            ka.setDisplayCode(item.getCode());
+            ka.setName(item.getName());
+            toSave.add(ka);
+        }
+
+        knownAssetRepository.deleteByAssetType("STOCK_TWO");
+        knownAssetRepository.saveAll(toSave);
+        log.info("TPEX 同步完成：{} 筆", toSave.size());
+        return toSave.size();
     }
 
     // ────────────── CoinGecko 加密貨幣 ──────────────
 
+    /**
+     * 從 /coins/markets 抓前 1000 名的市值排名（每頁 250 筆，共 4 頁）。
+     * 免費 API rate limit 約 30 req/min，4 頁之間各 sleep 2s。
+     */
+    private java.util.Map<String, Integer> fetchMarketCapRanks() {
+        java.util.Map<String, Integer> rankMap = new java.util.HashMap<>();
+        WebClient client = webClientBuilder.baseUrl(coinGeckoBaseUrl).build();
+        for (int page = 1; page <= 4; page++) {
+            try {
+                int p = page;
+                List<CoinGeckoMarketItem> pageItems = client.get()
+                        .uri(u -> u.path("/coins/markets")
+                                .queryParam("vs_currency", "usd")
+                                .queryParam("order", "market_cap_desc")
+                                .queryParam("per_page", 250)
+                                .queryParam("page", p)
+                                .build())
+                        .retrieve()
+                        .bodyToFlux(CoinGeckoMarketItem.class)
+                        .collectList()
+                        .block();
+                if (pageItems != null) {
+                    pageItems.forEach(item -> {
+                        if (item.getId() != null && item.getMarketCapRank() != null) {
+                            rankMap.put(item.getId(), item.getMarketCapRank());
+                        }
+                    });
+                }
+                if (page < 4) Thread.sleep(2000); // 避免 rate limit
+            } catch (Exception e) {
+                log.warn("fetchMarketCapRanks page {} 失敗，繼續其餘頁: {}", page, e.getMessage());
+            }
+        }
+        log.info("市值排名同步完成：{} 筆", rankMap.size());
+        return rankMap;
+    }
+
+    @Retryable(maxAttempts = 3, backoff = @Backoff(delay = 2000, multiplier = 2))
     @Transactional
     public int syncCrypto() {
         log.info("開始同步 CoinGecko 加密貨幣清單...");
-        try {
-            // CoinGecko /coins/list 回應約 1MB，超過 WebClient 預設 256KB buffer，需明確指定上限
-            ExchangeStrategies strategies = ExchangeStrategies.builder()
-                    .codecs(config -> config.defaultCodecs().maxInMemorySize(5 * 1024 * 1024)) // 5MB
-                    .build();
-            List<CoinGeckoListItem> items = webClientBuilder.baseUrl(coinGeckoBaseUrl)
-                    .exchangeStrategies(strategies)
-                    .build()
-                    .get().uri("/coins/list")
-                    .retrieve()
-                    .bodyToFlux(CoinGeckoListItem.class)
-                    .collectList()
-                    .block();
 
-            if (items == null || items.size() < CRYPTO_MIN_COUNT) {
-                log.warn("CoinGecko 回傳資料量異常（{}筆），跳過本次同步", items == null ? 0 : items.size());
-                return 0;
-            }
+        // 先取得前 1000 名市值排名
+        java.util.Map<String, Integer> rankMap = fetchMarketCapRanks();
 
-            List<KnownAsset> toSave = new ArrayList<>();
-            for (CoinGeckoListItem item : items) {
-                if (item.getId() == null || item.getSymbol() == null || item.getName() == null) continue;
-                KnownAsset ka = new KnownAsset();
-                ka.setAssetType("CRYPTO");
-                ka.setSymbol(item.getId());                         // CoinGecko id，例如 "bitcoin"
-                ka.setDisplayCode(item.getSymbol().toUpperCase());  // 例如 "BTC"
-                ka.setName(item.getName());                         // 例如 "Bitcoin"
-                toSave.add(ka);
-            }
+        // CoinGecko /coins/list 回應約 1MB，超過 WebClient 預設 256KB buffer，需明確指定上限
+        ExchangeStrategies strategies = ExchangeStrategies.builder()
+                .codecs(config -> config.defaultCodecs().maxInMemorySize(5 * 1024 * 1024)) // 5MB
+                .build();
+        List<CoinGeckoListItem> items = webClientBuilder.baseUrl(coinGeckoBaseUrl)
+                .exchangeStrategies(strategies)
+                .build()
+                .get().uri("/coins/list")
+                .retrieve()
+                .bodyToFlux(CoinGeckoListItem.class)
+                .collectList()
+                .block();
 
-            knownAssetRepository.deleteByAssetType("CRYPTO");
-            knownAssetRepository.saveAll(toSave);
-            log.info("CoinGecko 同步完成：{} 筆", toSave.size());
-            return toSave.size();
-
-        } catch (Exception e) {
-            log.error("CoinGecko 同步失敗：{}", e.getMessage(), e);
+        if (items == null || items.size() < CRYPTO_MIN_COUNT) {
+            log.warn("CoinGecko 回傳資料量異常（{}筆），跳過本次同步", items == null ? 0 : items.size());
             return 0;
         }
+
+        List<KnownAsset> toSave = new ArrayList<>();
+        for (CoinGeckoListItem item : items) {
+            if (item.getId() == null || item.getSymbol() == null || item.getName() == null) continue;
+            KnownAsset ka = new KnownAsset();
+            ka.setAssetType("CRYPTO");
+            ka.setSymbol(item.getId());                         // CoinGecko id，例如 "bitcoin"
+            ka.setDisplayCode(item.getSymbol().toUpperCase());  // 例如 "BTC"
+            ka.setName(item.getName());                         // 例如 "Bitcoin"
+            ka.setMarketCapRank(rankMap.get(item.getId()));     // 前 1000 名有值，其餘 null
+            toSave.add(ka);
+        }
+
+        knownAssetRepository.deleteByAssetType("CRYPTO");
+        knownAssetRepository.saveAll(toSave);
+        log.info("CoinGecko 同步完成：{} 筆", toSave.size());
+        return toSave.size();
     }
 
     // ────────────── 全部同步 ──────────────
 
     public void syncAll() {
-        int twse = syncTwse();
-        int tpex = syncTpex();
-        int crypto = syncCrypto();
+        int twse = syncSafe("TWSE", this::syncTwse);
+        int tpex = syncSafe("TPEX", this::syncTpex);
+        int crypto = syncSafe("CoinGecko", this::syncCrypto);
         log.info("資產清單全量同步完成 — TWSE: {}, TPEX: {}, Crypto: {}", twse, tpex, crypto);
+    }
+
+    // 包裝每個 sync 方法：3 次 retry 都失敗後記錄 error，不讓例外往上傳讓 scheduler 中斷
+    private int syncSafe(String source, java.util.function.IntSupplier syncFn) {
+        try {
+            return syncFn.getAsInt();
+        } catch (Exception e) {
+            log.error("{} 同步最終失敗（已重試 3 次）：{}", source, e.getMessage());
+            return 0;
+        }
     }
 
     // ────────────── 內部 DTO ──────────────
@@ -199,5 +239,13 @@ public class KnownAssetSyncService {
         private String id;
         private String symbol;
         private String name;
+    }
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    static class CoinGeckoMarketItem {
+        private String id;
+        @JsonProperty("market_cap_rank")
+        private Integer marketCapRank;
     }
 }

--- a/backend/src/main/java/com/pocketfolio/backend/service/external/CoinGeckoService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/external/CoinGeckoService.java
@@ -35,12 +35,13 @@ public class CoinGeckoService {
     )
     public PriceData getPrice(String coinGeckoId) {
         try {
-            log.info("呼叫 CoinGecko API: {}", coinGeckoId);
+            String id = coinGeckoId.toLowerCase();
+            log.info("呼叫 CoinGecko API: {}", id);
 
             WebClient webClient = webClientBuilder.baseUrl(baseUrl).build();
 
             CoinGeckoResponse response = webClient.get()
-                    .uri("/coins/{id}", coinGeckoId)
+                    .uri("/coins/{id}", id)
                     .retrieve()
                     .bodyToMono(CoinGeckoResponse.class)
                     .block();
@@ -50,14 +51,14 @@ public class CoinGeckoService {
                 BigDecimal price = response.getMarketData().getUsdPrice();
                 log.info("CoinGecko - {} 價格: ${}", coinGeckoId, price);
                 return PriceData.builder()
-                        .symbol(coinGeckoId)
+                        .symbol(id)
                         .price(price)
                         .updateTime(LocalDateTime.now())
                         .source("CoinGecko")
                         .build();
             }
 
-            log.warn("CoinGecko - 無法取得 {} 的價格", coinGeckoId);
+            log.warn("CoinGecko - 無法取得 {} 的價格", id);
             return null;
 
         } catch (Exception e) {

--- a/backend/src/main/java/com/pocketfolio/backend/service/external/CoinGeckoService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/external/CoinGeckoService.java
@@ -11,8 +11,6 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -24,45 +22,25 @@ public class CoinGeckoService {
     @Value("${api.coingecko.base-url}")
     private String baseUrl;
 
-    // Symbol 映射表（CoinGecko 使用的 ID）
-    private static final Map<String, String> SYMBOL_TO_ID = new HashMap<>() {{
-        put("BTC", "bitcoin");
-        put("ETH", "ethereum");
-        put("BNB", "binancecoin");
-        put("XRP", "ripple");
-        put("ADA", "cardano");
-        put("SOL", "solana");
-        put("DOGE", "dogecoin");
-        put("MATIC", "matic-network");
-        // 可以繼續新增更多
-    }};
-
     /**
      * 取得加密貨幣即時價格（USD）
      *
-     * @param symbol 代號，例如：BTC, ETH
+     * @param coinGeckoId CoinGecko coin id，例如：bitcoin, ethereum（存在 Asset.symbol 欄位）
      * @return 價格（USD）
      */
     @Cacheable(
             value = "prices",
-            key = "'crypto:' + #symbol.toUpperCase()",
+            key = "'crypto:' + #coinGeckoId.toLowerCase()",
             unless = "#result == null"
     )
-    public PriceData getPrice(String symbol) {
-        String coinId = SYMBOL_TO_ID.get(symbol.toUpperCase());
-
-        if (coinId == null) {
-            log.warn("不支援的加密貨幣代號: {}", symbol);
-            return null;
-        }
-
+    public PriceData getPrice(String coinGeckoId) {
         try {
-            log.info("呼叫 CoinGecko API: {}", symbol);
+            log.info("呼叫 CoinGecko API: {}", coinGeckoId);
 
             WebClient webClient = webClientBuilder.baseUrl(baseUrl).build();
 
             CoinGeckoResponse response = webClient.get()
-                    .uri("/coins/{id}", coinId)
+                    .uri("/coins/{id}", coinGeckoId)
                     .retrieve()
                     .bodyToMono(CoinGeckoResponse.class)
                     .block();
@@ -70,28 +48,21 @@ public class CoinGeckoService {
             if (response != null && response.getMarketData() != null) {
                 Thread.sleep(500);
                 BigDecimal price = response.getMarketData().getUsdPrice();
-                log.info("CoinGecko - {} 價格: ${}", symbol, price);
+                log.info("CoinGecko - {} 價格: ${}", coinGeckoId, price);
                 return PriceData.builder()
-                        .symbol(symbol)
+                        .symbol(coinGeckoId)
                         .price(price)
                         .updateTime(LocalDateTime.now())
                         .source("CoinGecko")
                         .build();
             }
 
-            log.warn("CoinGecko - 無法取得 {} 的價格", symbol);
+            log.warn("CoinGecko - 無法取得 {} 的價格", coinGeckoId);
             return null;
 
         } catch (Exception e) {
             log.error("CoinGecko API 呼叫失敗: {}", e.getMessage());
             return null;
         }
-    }
-
-    /**
-     * 檢查是否支援該加密貨幣
-     */
-    public boolean isSupported(String symbol) {
-        return SYMBOL_TO_ID.containsKey(symbol.toUpperCase());
     }
 }

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -8,6 +8,10 @@ spring:
     password: password
     driver-class-name: org.postgresql.Driver
 
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+
   jpa:
     hibernate:
       ddl-auto: update

--- a/backend/src/test/java/com/pocketfolio/backend/service/KnownAssetSyncServiceTest.java
+++ b/backend/src/test/java/com/pocketfolio/backend/service/KnownAssetSyncServiceTest.java
@@ -1,0 +1,118 @@
+package com.pocketfolio.backend.service;
+
+import com.pocketfolio.backend.repository.KnownAssetRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Flux;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@SuppressWarnings({"unchecked", "rawtypes"})
+@ExtendWith(MockitoExtension.class)
+class KnownAssetSyncServiceTest {
+
+    @Mock private KnownAssetRepository knownAssetRepository;
+    @Mock private WebClient.Builder webClientBuilder;
+    @Mock private WebClient webClient;
+    // raw type 避免 Mockito wildcard 型別推斷失敗
+    @Mock private WebClient.RequestHeadersUriSpec requestHeadersUriSpec;
+    @Mock private WebClient.RequestHeadersSpec requestHeadersSpec;
+    @Mock private WebClient.ResponseSpec responseSpec;
+
+    private KnownAssetSyncService syncService;
+
+    @BeforeEach
+    void setUp() {
+        syncService = new KnownAssetSyncService(knownAssetRepository, webClientBuilder);
+        ReflectionTestUtils.setField(syncService, "coinGeckoBaseUrl", "https://api.coingecko.com/api/v3");
+
+        lenient().when(webClientBuilder.build()).thenReturn(webClient);
+        lenient().when(webClientBuilder.baseUrl(anyString())).thenReturn(webClientBuilder);
+        lenient().when(webClientBuilder.exchangeStrategies(any(org.springframework.web.reactive.function.client.ExchangeStrategies.class)))
+                .thenReturn(webClientBuilder);
+
+        lenient().when(webClient.get()).thenReturn(requestHeadersUriSpec);
+        lenient().when(requestHeadersUriSpec.uri(anyString())).thenReturn(requestHeadersSpec);
+        lenient().when(requestHeadersUriSpec.uri(any(java.util.function.Function.class))).thenReturn(requestHeadersSpec);
+        lenient().when(requestHeadersSpec.retrieve()).thenReturn(responseSpec);
+    }
+
+    // ────────────── TWSE Sanity Check ──────────────
+
+    @Nested
+    @DisplayName("syncTwse()")
+    class SyncTwse {
+
+        @Test
+        @DisplayName("API 回傳筆數低於閾值（500）時，不清除舊資料")
+        void sanityCheck_skipsWhenTooFewItems() {
+            given(responseSpec.bodyToFlux(KnownAssetSyncService.TwseItem.class))
+                    .willReturn(Flux.just(twseItem("2330"), twseItem("2317"), twseItem("2454")));
+
+            int result = syncService.syncTwse();
+
+            assertThat(result).isEqualTo(0);
+            verify(knownAssetRepository, never()).deleteByAssetType("STOCK_TW");
+            verify(knownAssetRepository, never()).saveAll(any());
+        }
+
+        @Test
+        @DisplayName("API 回傳空串列時，不清除舊資料")
+        void sanityCheck_skipsWhenEmpty() {
+            given(responseSpec.bodyToFlux(KnownAssetSyncService.TwseItem.class))
+                    .willReturn(Flux.empty());
+
+            int result = syncService.syncTwse();
+
+            assertThat(result).isEqualTo(0);
+            verify(knownAssetRepository, never()).deleteByAssetType("STOCK_TW");
+        }
+    }
+
+    // ────────────── TPEX Sanity Check ──────────────
+
+    @Nested
+    @DisplayName("syncTpex()")
+    class SyncTpex {
+
+        @Test
+        @DisplayName("API 回傳筆數低於閾值（400）時，不清除舊資料")
+        void sanityCheck_skipsWhenTooFewItems() {
+            given(responseSpec.bodyToFlux(KnownAssetSyncService.TpexItem.class))
+                    .willReturn(Flux.just(tpexItem("6547"), tpexItem("3008")));
+
+            int result = syncService.syncTpex();
+
+            assertThat(result).isEqualTo(0);
+            verify(knownAssetRepository, never()).deleteByAssetType("STOCK_TWO");
+            verify(knownAssetRepository, never()).saveAll(any());
+        }
+    }
+
+    // ────────────── Helper methods ──────────────
+
+    private KnownAssetSyncService.TwseItem twseItem(String code) {
+        KnownAssetSyncService.TwseItem item = new KnownAssetSyncService.TwseItem();
+        item.setCode(code);
+        item.setName("公司" + code);
+        return item;
+    }
+
+    private KnownAssetSyncService.TpexItem tpexItem(String code) {
+        KnownAssetSyncService.TpexItem item = new KnownAssetSyncService.TpexItem();
+        item.setCode(code);
+        item.setName("公司" + code);
+        return item;
+    }
+}

--- a/backend/src/test/java/com/pocketfolio/backend/service/KnownAssetSyncServiceTest.java
+++ b/backend/src/test/java/com/pocketfolio/backend/service/KnownAssetSyncServiceTest.java
@@ -100,6 +100,38 @@ class KnownAssetSyncServiceTest {
         }
     }
 
+    // ────────────── CoinGecko Sanity Check ──────────────
+
+    @Nested
+    @DisplayName("syncCrypto()")
+    class SyncCrypto {
+
+        @Test
+        @DisplayName("API 回傳筆數低於閾值（150）時，不清除舊資料")
+        void sanityCheck_skipsWhenTooFewItems() {
+            given(responseSpec.bodyToFlux(KnownAssetSyncService.CoinGeckoMarketItem.class))
+                    .willReturn(Flux.just(marketItem("bitcoin", "BTC", "Bitcoin", 1)));
+
+            int result = syncService.syncCrypto();
+
+            assertThat(result).isEqualTo(0);
+            verify(knownAssetRepository, never()).deleteByAssetType("CRYPTO");
+            verify(knownAssetRepository, never()).saveAll(any());
+        }
+
+        @Test
+        @DisplayName("API 回傳空串列時，不清除舊資料")
+        void sanityCheck_skipsWhenEmpty() {
+            given(responseSpec.bodyToFlux(KnownAssetSyncService.CoinGeckoMarketItem.class))
+                    .willReturn(Flux.empty());
+
+            int result = syncService.syncCrypto();
+
+            assertThat(result).isEqualTo(0);
+            verify(knownAssetRepository, never()).deleteByAssetType("CRYPTO");
+        }
+    }
+
     // ────────────── Helper methods ──────────────
 
     private KnownAssetSyncService.TwseItem twseItem(String code) {
@@ -113,6 +145,15 @@ class KnownAssetSyncServiceTest {
         KnownAssetSyncService.TpexItem item = new KnownAssetSyncService.TpexItem();
         item.setCode(code);
         item.setName("公司" + code);
+        return item;
+    }
+
+    private KnownAssetSyncService.CoinGeckoMarketItem marketItem(String id, String symbol, String name, int rank) {
+        KnownAssetSyncService.CoinGeckoMarketItem item = new KnownAssetSyncService.CoinGeckoMarketItem();
+        item.setId(id);
+        item.setSymbol(symbol);
+        item.setName(name);
+        item.setMarketCapRank(rank);
         return item;
     }
 }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,159 +1,114 @@
 # PocketFolio 待辦事項
 
-更新時間：2026-03-27
-
----
-
-## ✅ Phase 6 已全部完成
-
-- [x] WebSocket 即時價格更新（STOMP + SockJS，全域連線）
-- [x] 資產歷史快照頁面（投資組合走勢圖）
-- [x] 資料庫複合索引（user_id, date）
-
----
-
-## 🔴 Phase 7 優先：雲端部署
-
-**部署目標架構：**
-- 前端：Firebase Hosting（靜態 CDN）
-- 後端：GCP Cloud Run（容器化 Spring Boot）
-- 資料庫：GCP Cloud SQL（managed PostgreSQL）
-- 快取：Upstash（serverless Redis，免費）
-- CI/CD：GitHub Actions
-
-### 1. 後端容器化
-**預計時間：** 1-2 小時
-- [ ] 撰寫後端 `Dockerfile`（multi-stage build）
-- [ ] 本地測試 `docker build` 成功
-- [ ] 設定 `application-prod.yaml`（環境變數化所有敏感設定）
-
-### 2. GCP 環境設定
-**預計時間：** 1-2 小時
-- [ ] 建立 GCP 專案
-- [ ] 啟用 Cloud Run、Cloud SQL、Artifact Registry API
-- [ ] 建立 Cloud SQL PostgreSQL 實例
-- [ ] 設定 Upstash Redis（外部服務，免費）
-- [ ] 本地測試連接 Cloud SQL
-
-### 3. 前端部署設定
-**預計時間：** 30 分鐘
-- [ ] 設定 `frontend/.env.production`（API URL 指向 Cloud Run）
-- [ ] Firebase Hosting 初始化（`firebase init hosting`）
-
-### 4. GitHub Actions CI/CD
-**預計時間：** 1-2 小時
-- [ ] 撰寫 `.github/workflows/deploy-backend.yml`
-  - push main → build Docker → push Artifact Registry → deploy Cloud Run
-- [ ] 撰寫 `.github/workflows/deploy-frontend.yml`
-  - push main → npm build → deploy Firebase Hosting
-- [ ] 設定 GitHub Secrets（GCP 金鑰、各項環境變數）
-
----
-
-## 🟡 部署後持續改進
-
-### 4. Token 過期主動偵測
-**預計時間：** 30 分鐘
-- [ ] App 啟動時解析 JWT 的 `exp` 欄位，若已過期則清除 auth 狀態並導向 `/login`
-- [ ] 避免用戶看到已登入畫面但所有 API 操作都失敗的尷尬狀態
-
-**背景：** 目前 axios 攔截器會在 API 回傳 401 時跳轉，但啟動時不會主動檢查，導致使用者感覺「點了沒反應」
-
-### 5. 響應式設計優化
-**預計時間：** 3-4 小時
-- [ ] 手機版側邊欄優化
-- [ ] 表格在手機上的顯示
-- [ ] 圖表響應式調整
-- [ ] 統計卡片佈局
-
-### 5. Service 層重構
-**預計時間：** 2-3 小時
-- [ ] 提取共用驗證邏輯
-- [ ] 考慮使用 AOP 或 BaseService
-- [ ] 減少重複代碼
-
-### 6. Entity → DTO 轉換自動化
-**預計時間：** 2-3 小時
-- [ ] 整合 MapStruct
-- [ ] 自動生成 Mapper
-- [ ] 移除手動 toResponse() 方法
-
-### 7. 單元測試補完
-**預計時間：** 4-5 小時
-- [ ] CategoryServiceTest
-- [ ] AccountServiceTest
-- [ ] AssetServiceTest
-- [ ] PriceServiceTest
-- [ ] PriceAlertServiceTest
-- [ ] AssetSnapshotServiceTest
-
-### 8. 整合測試
-**預計時間：** 3-4 小時
-- [ ] API 層整合測試
-- [ ] WebSocket 測試
-- [ ] Redis 快取測試
-
----
-
-## 🟢 低優先級（後續優化）
-
-### 9. 前端優化
-- [ ] 代碼分割
-- [ ] 懶加載
-- [ ] React.memo 優化
-- [ ] 虛擬滾動（大列表）
-
-### 10. API 限流
-- [ ] Spring Cloud Gateway + Redis
-- [ ] 或使用 Bucket4j
-
-### 11. 監控與告警
-- [ ] Spring Boot Actuator
-- [ ] Prometheus + Grafana
-- [ ] 日誌聚合（ELK）
-
-### 12. 國際化
-- [ ] i18n 設定
-- [ ] 多語言支援
+更新時間：2026-03-30
 
 ---
 
 ## ✅ 已完成
 
-### Phase 1-5
-- [x] 基礎架構
-- [x] JWT 認證
-- [x] 所有 CRUD 功能
-- [x] 前端基礎頁面
-
-### Phase 6 ✅ 全部完成
-- [x] 資產管理頁面
-- [x] 統計分析圖表
-- [x] 價格警報頁面
-- [x] Dashboard 真實資料
+### Phase 1-6
+- [x] 基礎架構（Spring Boot + PostgreSQL）
+- [x] JWT 認證與多用戶資料隔離
+- [x] 所有 CRUD 功能（交易、類別、帳戶、資產、警報）
+- [x] Redis 快取 + 外部 API（CoinGecko / Yahoo Finance）
 - [x] WebSocket 即時價格更新與警報通知
 - [x] 資產歷史快照頁面
+- [x] 統計分析圖表
 - [x] 資料庫複合索引優化
+
+### Phase 7 — 部署與 CI/CD
+- [x] Docker multi-stage build
+- [x] GCP Cloud Run 後端部署
+- [x] Firebase Hosting 前端部署
+- [x] GitHub Actions CI/CD Pipeline
+- [x] Cloud SQL Auth Connector（Unix socket）
+- [x] Upstash Redis（TLS）
+
+### 部署後修復
+- [x] Token 過期自動導向 `/login`（axios interceptor + Zustand logout）
+- [x] WebSocket CORS — 補上 Firebase Hosting 網域到 `setAllowedOrigins`
+- [x] Dashboard 串接真實 API（月度統計、帳戶餘額、帳戶數量）
+- [x] 統計分析頁面啟用（新增 StatisticsPage、路由、側邊欄）
+- [x] 修正 StatisticsPage API 欄位對應（categoryBreakdown → incomeByCategory/expenseByCategory）
+- [x] 新用戶自動建立預設類別（餐飲、交通、娛樂、購物、住房、醫療、教育 / 薪資、獎金、投資收益、其他收入）
+- [x] 新用戶自動建立預設帳戶（現金、銀行帳戶、信用卡、投資帳戶）
+- [x] 資產搜尋 Autocomplete（known_assets 表 + TWSE/TPEX/CoinGecko 同步 + 前端 AutoComplete）
 
 ---
 
-## 🎯 本週目標
+## 🔴 高優先級
 
-**Week 11 (當前週):**
-1. WebSocket 即時更新 ✅
-2. 資產歷史快照頁面 ✅
-3. 資料庫索引優化 ✅
+### 1. 轉帳交易類別
+**問題：** 目前交易只有收入/支出兩種類型，無法記錄帳戶間轉帳。
+- [ ] 後端 TransactionType enum 加入 `TRANSFER`
+- [ ] 後端轉帳邏輯：一筆轉帳 = 來源帳戶支出 + 目標帳戶收入（需選擇來源/目標帳戶）
+- [ ] 前端新增交易表單加入轉帳類型 + 目標帳戶選擇
+- [ ] 統計分析排除轉帳（避免重複計算）
 
-**Week 12 (下週):**
-1. 響應式優化
-2. 效能調優
-3. Phase 6 收尾
+### 2. Autocomplete 改善（接續 PR #5）
+PR #5 待 merge，merge 後繼續：
+
+**a. Bitcoin 搜尋排名問題**
+- 問題：搜尋 "bitcoin" / "BTC" 出現大量垃圾幣，真正的比特幣被埋在後面
+- 解法：`KnownAsset` 加 `market_cap_rank` 欄位（nullable）
+  - 同步時先打 CoinGecko `/coins/markets?per_page=500` 取前 500 大市值幣並記錄排名
+  - 再打 `/coins/list` 補全其餘（排名為 null）
+  - 搜尋結果 `ORDER BY market_cap_rank NULLS LAST`
+
+**b. Retry + 指數退避**
+- 問題：TWSE/TPEX/CoinGecko 任一 API 偶發失敗時無重試
+- 解法：加入 `spring-retry` dependency，`syncTwse/syncTpex/syncCrypto` 各加 `@Retryable(maxAttempts=3, backoff=@Backoff(delay=2000, multiplier=2))`
+- 需在 `@SpringBootApplication` 加 `@EnableRetry`
+
+**c. Sanity check 測試**
+- 測試場景：mock WebClient 回傳 10 筆（低於閾值），驗證 `deleteByAssetType` 未被呼叫
+- 使用 `@SpringBootTest` + Mockito
+
+---
+
+## 🟡 中優先級
+
+### 3. 響應式設計優化
+- [ ] 手機版側邊欄（抽屜式 Drawer）
+- [ ] 表格在小螢幕的顯示方式
+- [ ] 圖表響應式調整
+- [ ] 統計卡片佈局（`xs` / `sm` / `md` breakpoints）
+
+### 4. Schema 遷移（Flyway）
+**時機：** 下次需要改動資料庫 schema 時引入，不用現在急。
+**現狀：** `ddl-auto: update` 可用但有風險（只加不刪欄位，複雜 migration 會失敗）。
+- [ ] 引入 Flyway dependency
+- [ ] 將現有 schema 轉成 `V1__init.sql`
+- [ ] `ddl-auto` 改為 `validate`
+
+### 5. 單元測試補完
+- [ ] KnownAssetSyncService sanity check 測試（API 回傳異常筆數，舊資料不被清除）
+- [ ] AssetServiceTest
+- [ ] PriceServiceTest
+
+---
+
+## 🟢 低優先級
+
+### 6. Service 層重構
+- [ ] 提取共用用戶驗證邏輯（目前各 service 重複）
+
+### 7. 監控
+- [ ] GCP Billing 預算警報（建議 $20/月上限）
+- [ ] Spring Boot Actuator + Cloud Run health check
+
+### 8. 前端效能
+- [ ] 代碼分割 + 懶加載
+- [ ] 大列表虛擬滾動
 
 ---
 
 ## 📝 筆記
 
-- displayName 取代 username（User Entity）
-- 循環依賴已解決（PriceService ⇄ PriceAlertService）
-- 前端使用 Zustand 做狀態管理
-- 圖表使用 Recharts
+- WebSocket 認證透過 STOMP connectHeaders 傳 JWT，非 HTTP header
+- CoinGecko 查詢用內部 `id`（如 `"bitcoin"`），不是 symbol（`"BTC"`）
+- Cloud Run 每次部署後 URL 不變，但 revision 會更新
+- `ddl-auto: update` 目前在用，未來換 Flyway 前先不動
+- GCP Cloud SQL 費用約 $7-10/月（db-f1-micro，asia-east1）
+- `known_assets` 欄位長度：symbol 100、display_code 50、name 200（CoinGecko 有超長 symbol 的垃圾幣）
+- TWSE suffix `.TW`，TPEX suffix `.TWO`，CRYPTO 存 CoinGecko id（如 `bitcoin`）

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -33,6 +33,10 @@
 - [x] 新用戶自動建立預設類別（餐飲、交通、娛樂、購物、住房、醫療、教育 / 薪資、獎金、投資收益、其他收入）
 - [x] 新用戶自動建立預設帳戶（現金、銀行帳戶、信用卡、投資帳戶）
 - [x] 資產搜尋 Autocomplete（known_assets 表 + TWSE/TPEX/CoinGecko 同步 + 前端 AutoComplete）
+- [x] Autocomplete 改善：改同步市值前 200（移除廢棄幣）、顯示排名標籤、CoinGecko ID 正規化小寫
+- [x] Retry + 指數退避（spring-retry @Retryable maxAttempts=3）+ Sanity check 測試
+- [x] 修正 Invalid Date（Jackson write-dates-as-timestamps=false）
+- [x] 修正價格更新 UI 誤報成功（檢查 result.success）
 
 ---
 
@@ -44,25 +48,6 @@
 - [ ] 後端轉帳邏輯：一筆轉帳 = 來源帳戶支出 + 目標帳戶收入（需選擇來源/目標帳戶）
 - [ ] 前端新增交易表單加入轉帳類型 + 目標帳戶選擇
 - [ ] 統計分析排除轉帳（避免重複計算）
-
-### 2. Autocomplete 改善（接續 PR #5）
-PR #5 待 merge，merge 後繼續：
-
-**a. Bitcoin 搜尋排名問題**
-- 問題：搜尋 "bitcoin" / "BTC" 出現大量垃圾幣，真正的比特幣被埋在後面
-- 解法：`KnownAsset` 加 `market_cap_rank` 欄位（nullable）
-  - 同步時先打 CoinGecko `/coins/markets?per_page=500` 取前 500 大市值幣並記錄排名
-  - 再打 `/coins/list` 補全其餘（排名為 null）
-  - 搜尋結果 `ORDER BY market_cap_rank NULLS LAST`
-
-**b. Retry + 指數退避**
-- 問題：TWSE/TPEX/CoinGecko 任一 API 偶發失敗時無重試
-- 解法：加入 `spring-retry` dependency，`syncTwse/syncTpex/syncCrypto` 各加 `@Retryable(maxAttempts=3, backoff=@Backoff(delay=2000, multiplier=2))`
-- 需在 `@SpringBootApplication` 加 `@EnableRetry`
-
-**c. Sanity check 測試**
-- 測試場景：mock WebClient 回傳 10 筆（低於閾值），驗證 `deleteByAssetType` 未被呼叫
-- 使用 `@SpringBootTest` + Mockito
 
 ---
 
@@ -82,7 +67,7 @@ PR #5 待 merge，merge 後繼續：
 - [ ] `ddl-auto` 改為 `validate`
 
 ### 5. 單元測試補完
-- [ ] KnownAssetSyncService sanity check 測試（API 回傳異常筆數，舊資料不被清除）
+- [x] KnownAssetSyncService sanity check 測試（TWSE / TPEX / CoinGecko 各 2 個測試案例）
 - [ ] AssetServiceTest
 - [ ] PriceServiceTest
 

--- a/frontend/src/api/knownAsset.api.ts
+++ b/frontend/src/api/knownAsset.api.ts
@@ -1,0 +1,17 @@
+import axios from './axios';
+
+export type KnownAssetType = 'STOCK_TW' | 'STOCK_TWO' | 'CRYPTO';
+
+export interface KnownAssetResult {
+  symbol: string;      // Yahoo/CoinGecko 相容代號：2330.TW、bitcoin
+  name: string;        // 顯示名稱：台積電、Bitcoin
+  displayCode: string; // 短代碼：2330、BTC
+  assetType: KnownAssetType;
+}
+
+export const knownAssetApi = {
+  search: (assetType: KnownAssetType, keyword: string) =>
+    axios
+      .get<KnownAssetResult[]>('/known-assets/search', { params: { assetType, keyword } })
+      .then((r) => r.data),
+};

--- a/frontend/src/api/knownAsset.api.ts
+++ b/frontend/src/api/knownAsset.api.ts
@@ -3,10 +3,11 @@ import axios from './axios';
 export type KnownAssetType = 'STOCK_TW' | 'STOCK_TWO' | 'CRYPTO';
 
 export interface KnownAssetResult {
-  symbol: string;      // Yahoo/CoinGecko 相容代號：2330.TW、bitcoin
-  name: string;        // 顯示名稱：台積電、Bitcoin
-  displayCode: string; // 短代碼：2330、BTC
+  symbol: string;        // Yahoo/CoinGecko 相容代號：2330.TW、bitcoin
+  name: string;          // 顯示名稱：台積電、Bitcoin
+  displayCode: string;   // 短代碼：2330、BTC
   assetType: KnownAssetType;
+  marketCapRank?: number; // 加密貨幣市值排名（前 1000 名有值，其餘 null）
 }
 
 export const knownAssetApi = {

--- a/frontend/src/api/price.api.ts
+++ b/frontend/src/api/price.api.ts
@@ -34,8 +34,8 @@ export const priceApi = {
   },
 
   // 批次更新我的資產價格
-  updateMyAssetPrices: async (): Promise<{ successCount: number }> => {
-    const response = await axios.post('/prices/update/my-assets');
+  updateMyAssetPrices: async (): Promise<PriceUpdateResponse[]> => {
+    const response = await axios.post<PriceUpdateResponse[]>('/prices/update/my-assets');
     return response.data;
   },
 

--- a/frontend/src/pages/assets/AssetList.tsx
+++ b/frontend/src/pages/assets/AssetList.tsx
@@ -1,13 +1,13 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Table,
   Button,
   Space,
   Modal,
   Form,
-  Input,
   InputNumber,
   Select,
+  AutoComplete,
   message,
   Popconfirm,
   Tag,
@@ -33,6 +33,7 @@ import dayjs from 'dayjs';
 import { assetApi } from '@/api/asset.api';
 import { accountApi } from '@/api/account.api';
 import { priceApi } from '@/api/price.api';
+import { knownAssetApi, type KnownAssetResult, type KnownAssetType } from '@/api/knownAsset.api';
 import { useWebSocketStore } from '@/store/websocketStore';
 import type { Asset, AssetRequest, AssetType } from '@/types/asset.types';
 import type { Account } from '@/types/account.types';
@@ -51,6 +52,42 @@ const AssetList = () => {
   const [updating, setUpdating] = useState(false);
   const [form] = Form.useForm();
   const { lastPriceUpdateAt } = useWebSocketStore();
+
+  // AutoComplete 狀態
+  // searchMarket 控制搜哪個清單（STOCK_TW / STOCK_TWO / CRYPTO），與送出的 type 欄位（STOCK / CRYPTO）分開
+  const [searchMarket, setSearchMarket] = useState<KnownAssetType>('STOCK_TW');
+  const [searchOptions, setSearchOptions] = useState<{ value: string; label: string; data: KnownAssetResult }[]>([]);
+  const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleAssetSearch = useCallback((keyword: string) => {
+    if (keyword.length < 1) {
+      setSearchOptions([]);
+      return;
+    }
+    if (debounceTimer.current) clearTimeout(debounceTimer.current);
+    debounceTimer.current = setTimeout(async () => {
+      try {
+        const results = await knownAssetApi.search(searchMarket, keyword);
+        setSearchOptions(
+          results.map((r) => ({
+            value: r.symbol,
+            label: `${r.displayCode}　${r.name}`,
+            data: r,
+          }))
+        );
+      } catch {
+        // 搜尋失敗靜默忽略
+      }
+    }, 300);
+  }, [searchMarket]);
+
+  const handleAssetSelect = useCallback((_value: string, option: { value: string; label: string; data: KnownAssetResult }) => {
+    form.setFieldsValue({
+      symbol: option.data.symbol,
+      name: option.data.name,
+    });
+    setSearchOptions([]);
+  }, [form]);
 
   // 載入資料
   useEffect(() => {
@@ -100,14 +137,20 @@ const AssetList = () => {
   const handleCreate = () => {
     setEditingAsset(null);
     form.resetFields();
-    form.setFieldsValue({ accountId: selectedAccount });
+    form.setFieldsValue({ accountId: selectedAccount, type: 'STOCK', _searchMarket: 'STOCK_TW' });
+
+    setSearchMarket('STOCK_TW');
+    setSearchOptions([]);
     setModalVisible(true);
   };
 
   // 編輯資產
   const handleEdit = (record: Asset) => {
     setEditingAsset(record);
-    form.setFieldsValue(record);
+    const market: KnownAssetType = record.type === 'CRYPTO' ? 'CRYPTO' : 'STOCK_TW';
+    form.setFieldsValue({ ...record, _searchMarket: market });
+    setSearchMarket(market);
+    setSearchOptions([]);
     setModalVisible(true);
   };
 
@@ -433,34 +476,53 @@ const AssetList = () => {
       >
         <Form form={form} layout="vertical" onFinish={handleSubmit}>
           <Form.Item name="accountId" hidden>
-            <Input />
+            <AutoComplete />
           </Form.Item>
+          {/* symbol / name 由 AutoComplete 選取後自動填入，用 hidden field 傳值 */}
+          <Form.Item name="symbol" hidden><AutoComplete /></Form.Item>
+          <Form.Item name="name" hidden><AutoComplete /></Form.Item>
+
+          {/* type 送後端（STOCK / CRYPTO），由 _searchMarket 選擇決定 */}
+          <Form.Item name="type" hidden><AutoComplete /></Form.Item>
 
           <Form.Item
             label="資產類型"
-            name="type"
+            name="_searchMarket"
             rules={[{ required: true, message: '請選擇資產類型' }]}
           >
-            <Radio.Group>
-              <Radio value="STOCK">股票</Radio>
+            <Radio.Group onChange={(e) => {
+              const market: KnownAssetType = e.target.value;
+              form.setFieldsValue({
+                type: market === 'CRYPTO' ? 'CRYPTO' : 'STOCK',
+                symbol: undefined,
+                name: undefined,
+              });
+              setSearchMarket(market);
+              setSearchOptions([]);
+            }}>
+              <Radio value="STOCK_TW">台股（上市）</Radio>
+              <Radio value="STOCK_TWO">台股（上櫃）</Radio>
               <Radio value="CRYPTO">加密貨幣</Radio>
             </Radio.Group>
           </Form.Item>
 
           <Form.Item
-            label="資產代號"
-            name="symbol"
-            rules={[{ required: true, message: '請輸入資產代號' }]}
+            label="搜尋資產"
+            name="_assetSearch"
+            rules={[{ validator: async () => {
+              if (!form.getFieldValue('symbol')) throw new Error('請選擇一個資產');
+            }}]}
           >
-            <Input placeholder="例如：AAPL, BTC" />
-          </Form.Item>
-
-          <Form.Item
-            label="資產名稱"
-            name="name"
-            rules={[{ required: true, message: '請輸入資產名稱' }]}
-          >
-            <Input placeholder="例如：蘋果公司, 比特幣" />
+            <AutoComplete
+              options={searchOptions}
+              onSearch={handleAssetSearch}
+              onSelect={handleAssetSelect}
+              placeholder={searchMarket === 'CRYPTO' ? '輸入名稱或代碼，例如：BTC、bitcoin' : '輸入股票代號或名稱，例如：2330、台積電'}
+              allowClear
+              onClear={() => {
+                form.setFieldsValue({ symbol: undefined, name: undefined });
+              }}
+            />
           </Form.Item>
 
           <Form.Item

--- a/frontend/src/pages/assets/AssetList.tsx
+++ b/frontend/src/pages/assets/AssetList.tsx
@@ -71,7 +71,9 @@ const AssetList = () => {
         setSearchOptions(
           results.map((r) => ({
             value: r.symbol,
-            label: `${r.displayCode}　${r.name}`,
+            label: r.marketCapRank
+              ? `${r.displayCode}　${r.name}　#${r.marketCapRank}`
+              : `${r.displayCode}　${r.name}`,
             data: r,
           }))
         );
@@ -168,9 +170,13 @@ const AssetList = () => {
   // 更新單個資產價格
   const handleUpdatePrice = async (id: string) => {
     try {
-      await priceApi.updateAssetPrice(id);
-      message.success('價格更新成功');
-      loadAssets();
+      const result = await priceApi.updateAssetPrice(id);
+      if (result.success) {
+        message.success('價格更新成功');
+        loadAssets();
+      } else {
+        message.error(`價格更新失敗：${result.errorMessage ?? '無法取得最新價格'}`);
+      }
     } catch (error) {
       message.error('價格更新失敗');
     }
@@ -180,8 +186,9 @@ const AssetList = () => {
   const handleUpdateAllPrices = async () => {
     setUpdating(true);
     try {
-      const result = await priceApi.updateMyAssetPrices();
-      message.success(`成功更新 ${result.successCount} 個資產價格`);
+      const results = await priceApi.updateMyAssetPrices();
+      const successCount = results.filter((r) => r.success).length;
+      message.success(`成功更新 ${successCount} 個資產價格`);
       loadAssets();
     } catch (error) {
       message.error('批次更新失敗');


### PR DESCRIPTION
## Summary
- 新增 `known_assets` 表，每天從 TWSE、TPEX、CoinGecko 同步約 15,000 筆資產清單
- 搜尋 endpoint `GET /api/known-assets/search`，回傳最多 20 筆，ILIKE 匹配代號或名稱
- 前端 AutoComplete 取代原本的手動輸入框，debounce 300ms 呼叫 API
- 移除 CoinGeckoService 硬編碼 8 個幣種的 map，改直接使用 coinGeckoId

## Key Design Decisions
- **Sanity check**：API 回傳筆數低於閾值（TWSE<500、TPEX<400、Crypto<5000）時跳過同步，保留舊資料
- **原子性**：`deleteByAssetType + saveAll` 包在同一個 `@Transactional`，任一失敗全部 rollback
- **啟動初始化**：`@EventListener(ApplicationReadyEvent.class)` 偵測 DB 為空時自動執行首次同步
- **searchMarket vs type**：前端用 `_searchMarket`（STOCK_TW/STOCK_TWO/CRYPTO）控制搜哪個清單，送後端的 `type` 仍為 STOCK/CRYPTO

## Test plan
- [x] 首次部署後 `known_assets` 表自動填充，log 顯示同步筆數
- [x] 搜尋「台積電」或「2330」出現正確結果，選中後 symbol 自動填入 `2330.TW`
- [x] 搜尋「bitcoin」或「BTC」出現正確結果，symbol 填入 `bitcoin`
- [x] API 回傳異常筆數時，舊資料不被清除（需 mock 測試）

🤖 Generated with [Claude Code](https://claude.com/claude-code)