### PR TITLE
feat(transactions): transfer transaction (double-entry lite)

### DIFF
--- a/backend/src/main/java/com/pocketfolio/backend/dto/TransactionRequest.java
+++ b/backend/src/main/java/com/pocketfolio/backend/dto/TransactionRequest.java
@@ -1,5 +1,6 @@
 package com.pocketfolio.backend.dto;
 
+import com.pocketfolio.backend.entity.TransactionType;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
 
@@ -16,7 +17,15 @@ public class TransactionRequest {
 
     private LocalDate date;
 
+    @NotNull(message = "交易類型不能為空")
+    private TransactionType type;
+
+    // INCOME / EXPENSE 使用；TRANSFER 不需要
     private UUID categoryId;
 
+    // 來源帳戶（所有類型）
     private UUID accountId;
+
+    // 目標帳戶（TRANSFER_OUT 類型使用）
+    private UUID toAccountId;
 }

--- a/backend/src/main/java/com/pocketfolio/backend/dto/TransactionResponse.java
+++ b/backend/src/main/java/com/pocketfolio/backend/dto/TransactionResponse.java
@@ -1,8 +1,8 @@
 package com.pocketfolio.backend.dto;
 
-import com.pocketfolio.backend.entity.Account;
 import com.pocketfolio.backend.entity.AccountType;
 import com.pocketfolio.backend.entity.CategoryType;
+import com.pocketfolio.backend.entity.TransactionType;
 import lombok.Builder;
 import lombok.Data;
 import java.math.BigDecimal;
@@ -13,9 +13,11 @@ import java.util.UUID;
 @Builder
 public class TransactionResponse {
     private UUID id;
+    private TransactionType type;
     private BigDecimal amount;
     private String note;
     private LocalDate date;
+    private UUID transferGroupId;
 
     private UUID categoryId;
     private String categoryName;
@@ -24,4 +26,8 @@ public class TransactionResponse {
     private UUID accountId;
     private String accountName;
     private AccountType accountType;
+
+    // 轉帳目標帳戶（type = TRANSFER_OUT 時有值）
+    private UUID toAccountId;
+    private String toAccountName;
 }

--- a/backend/src/main/java/com/pocketfolio/backend/entity/Transaction.java
+++ b/backend/src/main/java/com/pocketfolio/backend/entity/Transaction.java
@@ -18,6 +18,10 @@ public class Transaction {
     @GeneratedValue(strategy = GenerationType.UUID)
     private UUID id;
 
+    @Enumerated(EnumType.STRING)
+    @Column(name = "transaction_type", nullable = false)
+    private TransactionType type;
+
     @Column(nullable = false)
     private BigDecimal amount;
 
@@ -25,6 +29,10 @@ public class Transaction {
 
     @Column(nullable = false)
     private LocalDate date;
+
+    // 轉帳配對 ID：TRANSFER_OUT 與 TRANSFER_IN 共用同一個 UUID
+    @Column(name = "transfer_group_id")
+    private UUID transferGroupId;
 
     @ManyToOne
     @JoinColumn(name = "category_id")

--- a/backend/src/main/java/com/pocketfolio/backend/entity/TransactionType.java
+++ b/backend/src/main/java/com/pocketfolio/backend/entity/TransactionType.java
@@ -1,0 +1,8 @@
+package com.pocketfolio.backend.entity;
+
+public enum TransactionType {
+    INCOME,
+    EXPENSE,
+    TRANSFER_OUT,
+    TRANSFER_IN
+}

--- a/backend/src/main/java/com/pocketfolio/backend/repository/TransactionRepository.java
+++ b/backend/src/main/java/com/pocketfolio/backend/repository/TransactionRepository.java
@@ -6,11 +6,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.security.core.parameters.P;
 
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 public interface TransactionRepository extends JpaRepository<Transaction, UUID> {
@@ -27,10 +27,11 @@ public interface TransactionRepository extends JpaRepository<Transaction, UUID> 
 
     Page<Transaction> findByUserIdAndCategoryIdAndDateBetween(UUID userId, UUID categoryId, LocalDate startDate, LocalDate endDate, Pageable pageable);
 
-    // 統計：某用戶某帳戶的總金額（含收入/支出判斷)
+    // 統計：某用戶某帳戶的淨額
+    // INCOME / TRANSFER_IN → 正；EXPENSE / TRANSFER_OUT → 負
     @Query("SELECT COALESCE(SUM(CASE " +
-            "WHEN t.category IS NULL THEN -t.amount " +
-            "WHEN t.category.type = 'INCOME' THEN t.amount " +
+            "WHEN t.type = com.pocketfolio.backend.entity.TransactionType.INCOME THEN t.amount " +
+            "WHEN t.type = com.pocketfolio.backend.entity.TransactionType.TRANSFER_IN THEN t.amount " +
             "ELSE -t.amount END), 0) " +
             "FROM Transaction t WHERE t.account.id = :accountId AND t.user.id = :userId")
     BigDecimal calculateNetAmountByAccountIdAndUserId(
@@ -38,12 +39,17 @@ public interface TransactionRepository extends JpaRepository<Transaction, UUID> 
             @Param("userId") UUID userId
     );
 
-    // 查詢某用戶某年某月的所有交易
+    // 查詢某用戶某年某月的所有交易（排除轉帳，用於統計）
     @Query("SELECT t FROM Transaction t WHERE t.user.id = :userId " +
-            "AND YEAR(t.date) = :year AND MONTH(t.date) = :month")
+            "AND YEAR(t.date) = :year AND MONTH(t.date) = :month " +
+            "AND t.type NOT IN (com.pocketfolio.backend.entity.TransactionType.TRANSFER_OUT, " +
+            "com.pocketfolio.backend.entity.TransactionType.TRANSFER_IN)")
     List<Transaction> findByUserIdAndYearAndMonth(
             @Param("userId") UUID userId,
             @Param("year") int year,
             @Param("month") int month
     );
+
+    // 找轉帳配對記錄（刪除時用）
+    Optional<Transaction> findByTransferGroupIdAndIdNot(UUID transferGroupId, UUID excludeId);
 }

--- a/backend/src/main/java/com/pocketfolio/backend/service/StaticsService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/StaticsService.java
@@ -1,8 +1,8 @@
 package com.pocketfolio.backend.service;
 
 import com.pocketfolio.backend.dto.MonthlySummaryResponse;
-import com.pocketfolio.backend.entity.CategoryType;
 import com.pocketfolio.backend.entity.Transaction;
+import com.pocketfolio.backend.entity.TransactionType;
 import com.pocketfolio.backend.repository.TransactionRepository;
 import com.pocketfolio.backend.security.SecurityUtil;
 import lombok.RequiredArgsConstructor;
@@ -21,19 +21,18 @@ public class StaticsService {
 
     private final TransactionRepository transactionRepository;
 
-    // 月度收支統計
+    // 月度收支統計（轉帳已由 Repository 查詢排除）
     public MonthlySummaryResponse getMonthlySummary(int year, int month) {
         UUID currentUserId = SecurityUtil.getCurrentUserId();
 
-        // 只查詢當前用戶的交易
+        // 只查詢當前用戶的交易（不含轉帳）
         List<Transaction> transactions = transactionRepository
                 .findByUserIdAndYearAndMonth(currentUserId, year, month);
 
-        // 分離收入和支出
+        // 分離收入和支出（依 TransactionType 判斷）
         Map<Boolean, List<Transaction>> byType = transactions.stream()
-                .filter(tx -> tx.getCategory() != null)
                 .collect(Collectors.partitioningBy(
-                        tx -> tx.getCategory().getType() == CategoryType.INCOME
+                        tx -> tx.getType() == TransactionType.INCOME
                 ));
 
         List<Transaction> incomeTransactions = byType.get(true);
@@ -71,11 +70,12 @@ public class StaticsService {
                 .build();
     }
 
-    // Helper: 依類別分組統計
+    // Helper: 依類別分組統計（無類別的交易略過）
     private List<MonthlySummaryResponse.CategorySummary> groupByCategory(
             List<Transaction> transactions, BigDecimal total
     ) {
         Map<String, BigDecimal> categoryMap = transactions.stream()
+                .filter(tx -> tx.getCategory() != null)
                 .collect(Collectors.groupingBy(
                         tx -> tx.getCategory().getName(),
                         Collectors.mapping(

--- a/backend/src/main/java/com/pocketfolio/backend/service/TransactionService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/TransactionService.java
@@ -5,6 +5,7 @@ import com.pocketfolio.backend.dto.TransactionResponse;
 import com.pocketfolio.backend.entity.Account;
 import com.pocketfolio.backend.entity.Category;
 import com.pocketfolio.backend.entity.Transaction;
+import com.pocketfolio.backend.entity.TransactionType;
 import com.pocketfolio.backend.entity.User;
 import com.pocketfolio.backend.exception.ResourceNotFoundException;
 import com.pocketfolio.backend.repository.AccountRepository;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.UUID;
@@ -28,25 +30,24 @@ public class TransactionService {
     private final AccountRepository accountRepository;
 
     //Create
+    @Transactional
     public TransactionResponse createTransaction(TransactionRequest request) {
+        if (request.getType() == TransactionType.TRANSFER_OUT) {
+            return createTransfer(request);
+        }
+
         UUID currentUserId = SecurityUtil.getCurrentUserId();
-        Transaction tx = new Transaction();
-        tx.setAmount(request.getAmount());
-        tx.setNote(request.getNote());
-        tx.setDate(request.getDate() != null ? request.getDate() : LocalDate.now());
-        tx.setUser(new User());
-        tx.getUser().setId(currentUserId);
+        Transaction tx = buildBase(request, currentUserId);
+        tx.setType(request.getType());
 
         if (request.getCategoryId() != null) {
             Category category = categoryRepository.findById(request.getCategoryId())
                     .orElseThrow(() -> new ResourceNotFoundException(
                             "找不到 ID 為 " + request.getCategoryId() + " 的類別"
                     ));
-            // 驗證類別屬於當前用戶
             if (!category.getUser().getId().equals(currentUserId)) {
                 throw new IllegalArgumentException("無權使用此類別");
             }
-
             tx.setCategory(category);
         }
 
@@ -55,15 +56,58 @@ public class TransactionService {
                     .orElseThrow(() -> new ResourceNotFoundException(
                             "找不到 ID 為 " + request.getAccountId() + " 的帳戶"
                     ));
-            //驗證帳戶屬於當前用戶
             if (!account.getUser().getId().equals(currentUserId)) {
                 throw new IllegalArgumentException("無權使用此帳戶");
             }
-
             tx.setAccount(account);
         }
 
         return toResponse(repository.save(tx));
+    }
+
+    // 建立一組轉帳（TRANSFER_OUT + TRANSFER_IN），共用同一個 transferGroupId
+    private TransactionResponse createTransfer(TransactionRequest request) {
+        UUID currentUserId = SecurityUtil.getCurrentUserId();
+
+        if (request.getAccountId() == null || request.getToAccountId() == null) {
+            throw new IllegalArgumentException("轉帳需要來源帳戶與目標帳戶");
+        }
+        if (request.getAccountId().equals(request.getToAccountId())) {
+            throw new IllegalArgumentException("來源帳戶與目標帳戶不能相同");
+        }
+
+        Account fromAccount = accountRepository.findById(request.getAccountId())
+                .orElseThrow(() -> new ResourceNotFoundException("找不到來源帳戶"));
+        if (!fromAccount.getUser().getId().equals(currentUserId)) {
+            throw new IllegalArgumentException("無權使用此帳戶");
+        }
+
+        Account toAccount = accountRepository.findById(request.getToAccountId())
+                .orElseThrow(() -> new ResourceNotFoundException("找不到目標帳戶"));
+        if (!toAccount.getUser().getId().equals(currentUserId)) {
+            throw new IllegalArgumentException("無權使用此帳戶");
+        }
+
+        UUID groupId = UUID.randomUUID();
+
+        Transaction out = buildBase(request, currentUserId);
+        out.setType(TransactionType.TRANSFER_OUT);
+        out.setAccount(fromAccount);
+        out.setTransferGroupId(groupId);
+
+        Transaction in = buildBase(request, currentUserId);
+        in.setType(TransactionType.TRANSFER_IN);
+        in.setAccount(toAccount);
+        in.setTransferGroupId(groupId);
+
+        repository.save(in);
+        Transaction savedOut = repository.save(out);
+
+        // Response 以 TRANSFER_OUT 為主，附帶目標帳戶資訊
+        TransactionResponse response = toResponse(savedOut);
+        response.setToAccountId(toAccount.getId());
+        response.setToAccountName(toAccount.getName());
+        return response;
     }
 
     //Read(單筆)
@@ -79,14 +123,13 @@ public class TransactionService {
             throw new ResourceNotFoundException("找不到 ID 為 " + id + " 的交易");
         }
 
-        return toResponse(tx);
+        return toResponseWithTransferInfo(tx);
     }
 
     //Read(分頁列表)
-    //Pageable 由 Controller 傳入，可帶 page / size / sort 參數
     public Page<TransactionResponse> getAllTransactions(Pageable pageable) {
         UUID currentUserId = SecurityUtil.getCurrentUserId();
-        return repository.findByUserId(currentUserId, pageable).map(this::toResponse);
+        return repository.findByUserId(currentUserId, pageable).map(this::toResponseWithTransferInfo);
     }
 
     //Read (依類別)
@@ -100,7 +143,7 @@ public class TransactionService {
         }
 
         return repository.findByUserIdAndCategoryId(currentUserId, categoryId, pageable)
-                .map(this::toResponse);
+                .map(this::toResponseWithTransferInfo);
     }
 
     //Read (依帳戶)
@@ -114,7 +157,7 @@ public class TransactionService {
         }
 
         return repository.findByUserIdAndAccountId(currentUserId, accountId, pageable)
-                .map(this::toResponse);
+                .map(this::toResponseWithTransferInfo);
     }
 
     //Read (依日期範圍)
@@ -123,7 +166,7 @@ public class TransactionService {
     ) {
         UUID currentUserId = SecurityUtil.getCurrentUserId();
         return repository.findByUserIdAndDateBetween(currentUserId, startDate, endDate, pageable)
-                .map(this::toResponse);
+                .map(this::toResponseWithTransferInfo);
     }
 
     //Read (依帳戶與日期範圍)
@@ -132,7 +175,6 @@ public class TransactionService {
     ) {
         UUID currentUserId = SecurityUtil.getCurrentUserId();
 
-        // 驗證帳戶
         Account account = accountRepository.findById(accountId)
                 .orElseThrow(() -> new ResourceNotFoundException("找不到帳戶"));
         if (!account.getUser().getId().equals(currentUserId)) {
@@ -141,7 +183,7 @@ public class TransactionService {
 
         return repository.findByUserIdAndAccountIdAndDateBetween(
                         currentUserId, accountId, startDate, endDate, pageable)
-                .map(this::toResponse);
+                .map(this::toResponseWithTransferInfo);
     }
 
     //Read (依類別與日期範圍)
@@ -150,7 +192,6 @@ public class TransactionService {
     ) {
         UUID currentUserId = SecurityUtil.getCurrentUserId();
 
-        // 驗證類別
         Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new ResourceNotFoundException("找不到類別"));
         if (!category.getUser().getId().equals(currentUserId)) {
@@ -159,10 +200,11 @@ public class TransactionService {
 
         return repository.findByUserIdAndCategoryIdAndDateBetween(
                         currentUserId, categoryId, startDate, endDate, pageable)
-                .map(this::toResponse);
+                .map(this::toResponseWithTransferInfo);
     }
 
-    //Update
+    //Update（轉帳不支援編輯，需刪除重建）
+    @Transactional
     public TransactionResponse updateTransaction(UUID id, TransactionRequest request) {
         UUID currentUserId = SecurityUtil.getCurrentUserId();
 
@@ -170,18 +212,20 @@ public class TransactionService {
                 .orElseThrow(() -> new ResourceNotFoundException(
                         "找不到 ID 為 " + id + " 的交易"
                 ));
-        // 驗證交易屬於當前用戶
         if (!tx.getUser().getId().equals(currentUserId)) {
             throw new ResourceNotFoundException("找不到交易");
         }
+        if (tx.getType() == TransactionType.TRANSFER_OUT || tx.getType() == TransactionType.TRANSFER_IN) {
+            throw new IllegalArgumentException("轉帳記錄不支援編輯，請刪除後重新建立");
+        }
 
+        tx.setType(request.getType());
         tx.setAmount(request.getAmount());
         tx.setNote(request.getNote());
         if (request.getDate() != null) {
             tx.setDate(request.getDate());
         }
 
-        // 更新類別關聯（需驗證）
         if (request.getCategoryId() != null) {
             Category category = categoryRepository.findById(request.getCategoryId())
                     .orElseThrow(() -> new ResourceNotFoundException("找不到類別"));
@@ -193,7 +237,6 @@ public class TransactionService {
             tx.setCategory(null);
         }
 
-        // 更新帳戶關聯（需驗證）
         if (request.getAccountId() != null) {
             Account account = accountRepository.findById(request.getAccountId())
                     .orElseThrow(() -> new ResourceNotFoundException("找不到帳戶"));
@@ -208,28 +251,47 @@ public class TransactionService {
         return toResponse(repository.save(tx));
     }
 
-    //Delete
+    //Delete（轉帳連帶刪除配對記錄）
+    @Transactional
     public void deleteTransaction(UUID id) {
         UUID currentUserId = SecurityUtil.getCurrentUserId();
 
         Transaction tx = repository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("找不到交易"));
 
-        // 驗證交易屬於當前用戶
         if (!tx.getUser().getId().equals(currentUserId)) {
             throw new ResourceNotFoundException("找不到交易");
+        }
+
+        if (tx.getTransferGroupId() != null) {
+            repository.findByTransferGroupIdAndIdNot(tx.getTransferGroupId(), id)
+                    .ifPresent(repository::delete);
         }
 
         repository.deleteById(id);
     }
 
-    //Helper: Entity → DTO
+    // Helper: 建立基礎 Transaction（不含 type / account / category）
+    private Transaction buildBase(TransactionRequest request, UUID userId) {
+        Transaction tx = new Transaction();
+        tx.setAmount(request.getAmount());
+        tx.setNote(request.getNote());
+        tx.setDate(request.getDate() != null ? request.getDate() : LocalDate.now());
+        User user = new User();
+        user.setId(userId);
+        tx.setUser(user);
+        return tx;
+    }
+
+    // Helper: Entity → DTO（一般交易）
     private TransactionResponse toResponse(Transaction tx) {
-        TransactionResponse.TransactionResponseBuilder builder =  TransactionResponse.builder()
+        TransactionResponse.TransactionResponseBuilder builder = TransactionResponse.builder()
                 .id(tx.getId())
+                .type(tx.getType())
                 .amount(tx.getAmount())
                 .note(tx.getNote())
-                .date(tx.getDate());
+                .date(tx.getDate())
+                .transferGroupId(tx.getTransferGroupId());
 
         if (tx.getCategory() != null) {
             builder.categoryId(tx.getCategory().getId())
@@ -244,5 +306,22 @@ public class TransactionService {
         }
 
         return builder.build();
+    }
+
+    // Helper: Entity → DTO（含轉帳目標帳戶查詢）
+    private TransactionResponse toResponseWithTransferInfo(Transaction tx) {
+        TransactionResponse response = toResponse(tx);
+
+        if (tx.getType() == TransactionType.TRANSFER_OUT && tx.getTransferGroupId() != null) {
+            repository.findByTransferGroupIdAndIdNot(tx.getTransferGroupId(), tx.getId())
+                    .ifPresent(paired -> {
+                        if (paired.getAccount() != null) {
+                            response.setToAccountId(paired.getAccount().getId());
+                            response.setToAccountName(paired.getAccount().getName());
+                        }
+                    });
+        }
+
+        return response;
     }
 }

--- a/frontend/src/pages/transactions/TransactionList.tsx
+++ b/frontend/src/pages/transactions/TransactionList.tsx
@@ -19,12 +19,13 @@ import {
   EditOutlined,
   DeleteOutlined,
   SearchOutlined,
+  SwapOutlined,
 } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import { transactionApi } from '@/api/transaction.api';
 import { categoryApi } from '@/api/category.api';
 import { accountApi } from '@/api/account.api';
-import type { Transaction, TransactionRequest } from '@/types/transaction.types';
+import type { Transaction, TransactionRequest, TransactionType } from '@/types/transaction.types';
 import type { Category } from '@/types/category.types';
 import type { Account } from '@/types/account.types';
 import type { ColumnsType } from 'antd/es/table';
@@ -40,22 +41,22 @@ const TransactionList = () => {
   const [accounts, setAccounts] = useState<Account[]>([]);
   const [modalVisible, setModalVisible] = useState(false);
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
+  const [selectedType, setSelectedType] = useState<TransactionType>('EXPENSE');
   const [form] = Form.useForm();
 
   // 篩選條件
   const [filters, setFilters] = useState<{
-  categoryId?: string;
-  accountId?: string;
-  startDate?: string;
-  endDate?: string;
-}>({
-  categoryId: undefined,
-  accountId: undefined,
-  startDate: undefined,
-  endDate: undefined,
-});
+    categoryId?: string;
+    accountId?: string;
+    startDate?: string;
+    endDate?: string;
+  }>({
+    categoryId: undefined,
+    accountId: undefined,
+    startDate: undefined,
+    endDate: undefined,
+  });
 
-  // 載入資料
   useEffect(() => {
     loadTransactions();
     loadCategories();
@@ -65,11 +66,9 @@ const TransactionList = () => {
   const loadTransactions = async () => {
     setLoading(true);
     try {
-      const response = await transactionApi.getTransactions({
-        ...filters,
-      });
-      setTransactions(response.content || response as any); // 處理分頁或陣列回應
-    } catch (error) {
+      const response = await transactionApi.getTransactions({ ...filters });
+      setTransactions(response.content || (response as any));
+    } catch {
       message.error('載入交易記錄失敗');
     } finally {
       setLoading(false);
@@ -78,51 +77,49 @@ const TransactionList = () => {
 
   const loadCategories = async () => {
     try {
-      const data = await categoryApi.getCategories();
-      setCategories(data);
-    } catch (error) {
-      console.error('載入類別失敗', error);
+      setCategories(await categoryApi.getCategories());
+    } catch {
+      console.error('載入類別失敗');
     }
   };
 
   const loadAccounts = async () => {
     try {
-      const data = await accountApi.getAccounts();
-      setAccounts(data);
-    } catch (error) {
-      console.error('載入帳戶失敗', error);
+      setAccounts(await accountApi.getAccounts());
+    } catch {
+      console.error('載入帳戶失敗');
     }
   };
 
-  // 新增交易
   const handleCreate = () => {
     setEditingTransaction(null);
+    setSelectedType('EXPENSE');
     form.resetFields();
+    form.setFieldsValue({ type: 'EXPENSE', date: dayjs() });
     setModalVisible(true);
   };
 
-  // 編輯交易
   const handleEdit = (record: Transaction) => {
+    if (record.type === 'TRANSFER_OUT' || record.type === 'TRANSFER_IN') {
+      message.warning('轉帳記錄不支援編輯，請刪除後重新建立');
+      return;
+    }
     setEditingTransaction(record);
-    form.setFieldsValue({
-      ...record,
-      date: dayjs(record.date),
-    });
+    setSelectedType(record.type);
+    form.setFieldsValue({ ...record, date: dayjs(record.date) });
     setModalVisible(true);
   };
 
-  // 刪除交易
   const handleDelete = async (id: string) => {
     try {
       await transactionApi.deleteTransaction(id);
       message.success('刪除成功');
       loadTransactions();
-    } catch (error) {
+    } catch {
       message.error('刪除失敗');
     }
   };
 
-  // 提交表單
   const handleSubmit = async (values: any) => {
     try {
       const requestData: TransactionRequest = {
@@ -140,37 +137,64 @@ const TransactionList = () => {
 
       setModalVisible(false);
       loadTransactions();
-    } catch (error) {
+    } catch {
       message.error(editingTransaction ? '更新失敗' : '新增失敗');
     }
   };
 
-  // 表格欄位
+  // 欄位顏色與符號
+  const amountColor = (type: TransactionType) => {
+    if (type === 'INCOME') return '#52c41a';
+    if (type === 'TRANSFER_OUT' || type === 'TRANSFER_IN') return '#1677ff';
+    return '#ff4d4f';
+  };
+
+  const amountPrefix = (type: TransactionType) => {
+    if (type === 'INCOME') return '+';
+    if (type === 'TRANSFER_IN') return '+';
+    return '-';
+  };
+
   const columns: ColumnsType<Transaction> = [
     {
       title: '日期',
       dataIndex: 'date',
       key: 'date',
-      width: 120,
+      width: 110,
       render: (date: string) => formatDate(date),
       sorter: (a, b) => dayjs(a.date).unix() - dayjs(b.date).unix(),
     },
     {
-      title: '類別',
-      dataIndex: 'categoryName',
-      key: 'categoryName',
-      width: 120,
-      render: (name: string, record: Transaction) => (
-        <Tag color={record.categoryType === 'INCOME' ? 'green' : 'red'}>
-          {name || '未分類'}
-        </Tag>
-      ),
+      title: '類型 / 類別',
+      key: 'typeCategory',
+      width: 160,
+      render: (_, record) => {
+        if (record.type === 'TRANSFER_OUT') {
+          return (
+            <Tag color="blue" icon={<SwapOutlined />}>
+              {record.accountName} → {record.toAccountName ?? '?'}
+            </Tag>
+          );
+        }
+        if (record.type === 'TRANSFER_IN') {
+          return (
+            <Tag color="blue" icon={<SwapOutlined />}>
+              轉入
+            </Tag>
+          );
+        }
+        return (
+          <Tag color={record.type === 'INCOME' ? 'green' : 'red'}>
+            {record.categoryName ?? '未分類'}
+          </Tag>
+        );
+      },
     },
     {
       title: '帳戶',
       dataIndex: 'accountName',
       key: 'accountName',
-      width: 120,
+      width: 110,
     },
     {
       title: '金額',
@@ -178,10 +202,9 @@ const TransactionList = () => {
       key: 'amount',
       width: 120,
       align: 'right',
-      render: (amount: number, record: Transaction) => (
-        <span style={{ color: record.categoryType === 'INCOME' ? '#52c41a' : '#ff4d4f' }}>
-          {record.categoryType === 'INCOME' ? '+' : '-'}
-          {formatCurrency(amount)}
+      render: (amount: number, record) => (
+        <span style={{ color: amountColor(record.type) }}>
+          {amountPrefix(record.type)}{formatCurrency(amount)}
         </span>
       ),
       sorter: (a, b) => a.amount - b.amount,
@@ -203,16 +226,26 @@ const TransactionList = () => {
             type="link"
             icon={<EditOutlined />}
             onClick={() => handleEdit(record)}
+            disabled={record.type === 'TRANSFER_IN'}
           >
             編輯
           </Button>
           <Popconfirm
-            title="確定要刪除嗎？"
+            title={
+              record.type === 'TRANSFER_OUT'
+                ? '刪除轉帳將同時刪除配對的轉入記錄，確定嗎？'
+                : '確定要刪除嗎？'
+            }
             onConfirm={() => handleDelete(record.id)}
             okText="確定"
             cancelText="取消"
           >
-            <Button type="link" danger icon={<DeleteOutlined />}>
+            <Button
+              type="link"
+              danger
+              icon={<DeleteOutlined />}
+              disabled={record.type === 'TRANSFER_IN'}
+            >
               刪除
             </Button>
           </Popconfirm>
@@ -221,9 +254,10 @@ const TransactionList = () => {
     },
   ];
 
+  const isTransfer = selectedType === 'TRANSFER_OUT';
+
   return (
     <div>
-      {/* 標題與操作按鈕 */}
       <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 16 }}>
         <Title level={2}>交易記錄</Title>
         <Button type="primary" icon={<PlusOutlined />} onClick={handleCreate}>
@@ -274,7 +308,6 @@ const TransactionList = () => {
         </Button>
       </Space>
 
-      {/* 表格 */}
       <Table
         columns={columns}
         dataSource={transactions}
@@ -295,42 +328,68 @@ const TransactionList = () => {
         footer={null}
         width={600}
       >
-        <Form
-          form={form}
-          layout="vertical"
-          onFinish={handleSubmit}
-        >
+        <Form form={form} layout="vertical" onFinish={handleSubmit}>
           <Form.Item
             label="日期"
             name="date"
             rules={[{ required: true, message: '請選擇日期' }]}
-            initialValue={dayjs()}
           >
             <DatePicker style={{ width: '100%' }} />
           </Form.Item>
 
           <Form.Item
-            label="類別"
-            name="categoryId"
-            rules={[{ required: true, message: '請選擇類別' }]}
+            label="交易類型"
+            name="type"
+            rules={[{ required: true, message: '請選擇交易類型' }]}
           >
-            <Select placeholder="請選擇類別">
-              {categories.map((cat) => (
-                <Select.Option key={cat.id} value={cat.id}>
-                  <Tag color={cat.type === 'INCOME' ? 'green' : 'red'}>
-                    {cat.type === 'INCOME' ? '收入' : '支出'}
-                  </Tag>
-                  {cat.name}
-                </Select.Option>
-              ))}
+            <Select
+              onChange={(v: TransactionType) => {
+                setSelectedType(v);
+                form.setFieldValue('categoryId', undefined);
+                form.setFieldValue('toAccountId', undefined);
+              }}
+              disabled={!!editingTransaction}
+            >
+              <Select.Option value="INCOME">
+                <Tag color="green">收入</Tag>
+              </Select.Option>
+              <Select.Option value="EXPENSE">
+                <Tag color="red">支出</Tag>
+              </Select.Option>
+              <Select.Option value="TRANSFER_OUT">
+                <Tag color="blue">轉帳</Tag>
+              </Select.Option>
             </Select>
           </Form.Item>
 
+          {/* 類別（收入/支出顯示） */}
+          {!isTransfer && (
+            <Form.Item
+              label="類別"
+              name="categoryId"
+              rules={[{ required: true, message: '請選擇類別' }]}
+            >
+              <Select placeholder="請選擇類別">
+                {categories
+                  .filter((cat) =>
+                    selectedType === 'INCOME' ? cat.type === 'INCOME' : cat.type === 'EXPENSE'
+                  )
+                  .map((cat) => (
+                    <Select.Option key={cat.id} value={cat.id}>
+                      {cat.name}
+                    </Select.Option>
+                  ))}
+              </Select>
+            </Form.Item>
+          )}
+
+          {/* 來源帳戶 */}
           <Form.Item
-            label="帳戶"
+            label={isTransfer ? '來源帳戶' : '帳戶'}
             name="accountId"
+            rules={isTransfer ? [{ required: true, message: '請選擇來源帳戶' }] : []}
           >
-            <Select placeholder="請選擇帳戶" allowClear>
+            <Select placeholder="請選擇帳戶" allowClear={!isTransfer}>
               {accounts.map((acc) => (
                 <Select.Option key={acc.id} value={acc.id}>
                   {acc.name}
@@ -338,6 +397,23 @@ const TransactionList = () => {
               ))}
             </Select>
           </Form.Item>
+
+          {/* 目標帳戶（轉帳顯示） */}
+          {isTransfer && (
+            <Form.Item
+              label="目標帳戶"
+              name="toAccountId"
+              rules={[{ required: true, message: '請選擇目標帳戶' }]}
+            >
+              <Select placeholder="請選擇目標帳戶">
+                {accounts.map((acc) => (
+                  <Select.Option key={acc.id} value={acc.id}>
+                    {acc.name}
+                  </Select.Option>
+                ))}
+              </Select>
+            </Form.Item>
+          )}
 
           <Form.Item
             label="金額"
@@ -355,15 +431,8 @@ const TransactionList = () => {
             />
           </Form.Item>
 
-          <Form.Item
-            label="備註"
-            name="note"
-            rules={[{ required: true, message: '請輸入備註' }]}
-          >
-            <Input.TextArea
-              placeholder="請輸入備註"
-              rows={3}
-            />
+          <Form.Item label="備註" name="note">
+            <Input.TextArea placeholder="請輸入備註" rows={3} />
           </Form.Item>
 
           <Form.Item>
@@ -371,9 +440,7 @@ const TransactionList = () => {
               <Button type="primary" htmlType="submit">
                 {editingTransaction ? '更新' : '新增'}
               </Button>
-              <Button onClick={() => setModalVisible(false)}>
-                取消
-              </Button>
+              <Button onClick={() => setModalVisible(false)}>取消</Button>
             </Space>
           </Form.Item>
         </Form>

--- a/frontend/src/types/transaction.types.ts
+++ b/frontend/src/types/transaction.types.ts
@@ -1,22 +1,30 @@
+export type TransactionType = 'INCOME' | 'EXPENSE' | 'TRANSFER_OUT' | 'TRANSFER_IN';
+
 // 交易記錄
 export interface Transaction {
   id: string;
+  type: TransactionType;
   amount: number;
   note: string;
   date: string;
+  transferGroupId?: string;
   categoryId?: string;
   categoryName?: string;
   categoryType?: 'INCOME' | 'EXPENSE';
   accountId?: string;
   accountName?: string;
   accountType?: 'CASH' | 'BANK' | 'CREDIT_CARD' | 'INVESTMENT';
+  toAccountId?: string;
+  toAccountName?: string;
 }
 
 // 交易請求
 export interface TransactionRequest {
+  type: TransactionType;
   amount: number;
-  note: string;
+  note?: string;
   date: string;
   categoryId?: string;
   accountId?: string;
+  toAccountId?: string;
 }


### PR DESCRIPTION
## Summary

- Add `TRANSFER_OUT` / `TRANSFER_IN` to `TransactionType` enum; linked by `transfer_group_id` UUID on `Transaction` entity
- Creating a transfer atomically inserts two paired records in one `@Transactional`; deleting either cascades to delete the other
- Account balance query updated to use `transaction_type` column (renamed from `type` to avoid PostgreSQL keyword conflict)
- Monthly statistics query excludes transfer records to avoid double-counting
- Frontend form shows target-account selector when transfer type is selected; transfer rows render as `A → B` with blue tag

## Schema change

New columns on `transactions` table (added automatically via `ddl-auto: update`):
- `transaction_type VARCHAR(20) NOT NULL`
- `transfer_group_id UUID NULL`

**Note:** Existing data requires migration — run `docker-compose down -v && docker-compose up -d` locally to reset, or run the migration SQL manually on shared environments.

## Test plan

- [x] Create INCOME / EXPENSE transaction — works as before
- [x] Create transfer: select source account, target account, amount → two records appear in list (TRANSFER_OUT + TRANSFER_IN)
- [x] Delete the TRANSFER_OUT record → both records are removed
- [x] TRANSFER_IN row: edit and delete buttons are disabled
- [x] Monthly statistics page does not count transfer amounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)