### PR TITLE
fix(price): move Thread.sleep from external services to scheduler loop

### DIFF
--- a/backend/src/main/java/com/pocketfolio/backend/service/PriceService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/PriceService.java
@@ -188,9 +188,13 @@ public class PriceService {
                     PriceUpdateResponse result = updateAssetPrice(asset.getId());
                     if (result.isSuccess()) {
                         successCount++;
+                        Thread.sleep(200); // 限速：避免連續 cache miss 時觸發外部 API rate limit
                     }
-
-                }catch (Exception e) {
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.warn("價格更新排程被中斷");
+                    return successCount;
+                } catch (Exception e) {
                     log.error("更新資產價格失敗: {} - {}", asset.getSymbol(), e.getMessage());
                 }
             }

--- a/backend/src/main/java/com/pocketfolio/backend/service/PriceService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/PriceService.java
@@ -192,7 +192,7 @@ public class PriceService {
                     }
                 } catch (InterruptedException e) {
                     Thread.currentThread().interrupt();
-                    log.warn("價格更新排程被中斷");
+                    log.warn("價格更新排程被中斷，已更新 {}/{} 筆", successCount, totalAssets);
                     return successCount;
                 } catch (Exception e) {
                     log.error("更新資產價格失敗: {} - {}", asset.getSymbol(), e.getMessage());

--- a/backend/src/main/java/com/pocketfolio/backend/service/external/CoinGeckoService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/external/CoinGeckoService.java
@@ -47,7 +47,6 @@ public class CoinGeckoService {
                     .block();
 
             if (response != null && response.getMarketData() != null) {
-                Thread.sleep(500);
                 BigDecimal price = response.getMarketData().getUsdPrice();
                 log.info("CoinGecko - {} 價格: ${}", coinGeckoId, price);
                 return PriceData.builder()

--- a/backend/src/main/java/com/pocketfolio/backend/service/external/YahooFinanceService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/external/YahooFinanceService.java
@@ -46,7 +46,6 @@ public class YahooFinanceService {
                     .block();
 
             if (response != null && response.getPrice() != null) {
-                Thread.sleep(500);
                 BigDecimal price = response.getPrice();
                 log.info("Yahoo Finance - {} 價格: {}", symbol, price);
 


### PR DESCRIPTION
## Summary
- `Thread.sleep(500)` was misplaced inside `CoinGeckoService.getPrice()` and `YahooFinanceService.getPrice()`, blocking threads on every call — including user-triggered single-asset price fetches
- Moved rate-limiting sleep (200ms) to `PriceService.updateAllAssetPrices()` batch loop, where it only applies to the scheduler and only when an actual API call was made (cache miss)
- Added proper `InterruptedException` handling per Java convention (`Thread.currentThread().interrupt()`)

## Test plan
- [x] Manually trigger a single asset price update — should return immediately without 500ms delay
- [x] Confirm scheduler still runs without errors (`updateAllAssetPrices` log output)

🤖 Generated with [Claude Code](https://claude.com/claude-code)