### PR TITLE
feat(transfer): link asset on transfer to investment account

### DIFF
--- a/backend/src/main/java/com/pocketfolio/backend/dto/TransactionRequest.java
+++ b/backend/src/main/java/com/pocketfolio/backend/dto/TransactionRequest.java
@@ -1,5 +1,6 @@
 package com.pocketfolio.backend.dto;
 
+import com.pocketfolio.backend.entity.AssetType;
 import com.pocketfolio.backend.entity.TransactionType;
 import jakarta.validation.constraints.NotNull;
 import lombok.Data;
@@ -28,4 +29,13 @@ public class TransactionRequest {
 
     // 目標帳戶（TRANSFER_OUT 類型使用）
     private UUID toAccountId;
+
+    // 資產連結（TRANSFER_OUT 轉入 INVESTMENT 帳戶時選填）
+    private UUID assetId;            // 現有資產 ID → 加倉
+    private AssetType assetType;     // 新資產類型（建立新資產時使用）
+    private String assetSymbol;      // 新資產代號
+    private String assetName;        // 新資產名稱
+    private BigDecimal assetQuantity;    // 數量（加倉或新增皆用）
+    private BigDecimal assetCostPrice;   // 單價（加倉或新增皆用；amount 由前端以 quantity × unitPrice 帶入）
+    private String assetNote;
 }

--- a/backend/src/main/java/com/pocketfolio/backend/service/TransactionService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/TransactionService.java
@@ -3,12 +3,16 @@ package com.pocketfolio.backend.service;
 import com.pocketfolio.backend.dto.TransactionRequest;
 import com.pocketfolio.backend.dto.TransactionResponse;
 import com.pocketfolio.backend.entity.Account;
+import com.pocketfolio.backend.entity.AccountType;
+import com.pocketfolio.backend.entity.Asset;
+import com.pocketfolio.backend.entity.AssetType;
 import com.pocketfolio.backend.entity.Category;
 import com.pocketfolio.backend.entity.Transaction;
 import com.pocketfolio.backend.entity.TransactionType;
 import com.pocketfolio.backend.entity.User;
 import com.pocketfolio.backend.exception.ResourceNotFoundException;
 import com.pocketfolio.backend.repository.AccountRepository;
+import com.pocketfolio.backend.repository.AssetRepository;
 import com.pocketfolio.backend.repository.CategoryRepository;
 import com.pocketfolio.backend.repository.TransactionRepository;
 import com.pocketfolio.backend.security.SecurityUtil;
@@ -18,6 +22,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
 import java.util.UUID;
 
@@ -28,6 +34,7 @@ public class TransactionService {
     private final TransactionRepository repository;
     private final CategoryRepository categoryRepository;
     private final AccountRepository accountRepository;
+    private final AssetRepository assetRepository;
 
     //Create
     @Transactional
@@ -103,11 +110,75 @@ public class TransactionService {
         repository.save(in);
         Transaction savedOut = repository.save(out);
 
+        linkAssetIfNeeded(request, toAccount, currentUserId);
+
         // Response 以 TRANSFER_OUT 為主，附帶目標帳戶資訊
         TransactionResponse response = toResponse(savedOut);
         response.setToAccountId(toAccount.getId());
         response.setToAccountName(toAccount.getName());
         return response;
+    }
+
+    // 資產連結：TRANSFER_OUT 轉入 INVESTMENT 帳戶時，同步更新或建立資產
+    private void linkAssetIfNeeded(TransactionRequest request, Account toAccount, UUID userId) {
+        if (toAccount.getType() != AccountType.INVESTMENT) return;
+
+        boolean hasExisting = request.getAssetId() != null;
+        boolean hasNew = request.getAssetSymbol() != null && !request.getAssetSymbol().isBlank();
+        if (!hasExisting && !hasNew) return;
+
+        if (request.getAssetQuantity() == null || request.getAssetQuantity().compareTo(BigDecimal.ZERO) <= 0) {
+            throw new IllegalArgumentException("加倉數量必須大於 0");
+        }
+
+        User user = new User();
+        user.setId(userId);
+
+        if (hasExisting) {
+            Asset asset = assetRepository.findById(request.getAssetId())
+                    .orElseThrow(() -> new ResourceNotFoundException("找不到資產"));
+            if (!asset.getUser().getId().equals(userId)) {
+                throw new IllegalArgumentException("無權操作此資產");
+            }
+            if (!asset.getAccount().getId().equals(toAccount.getId())) {
+                throw new IllegalArgumentException("資產不屬於目標帳戶");
+            }
+            BigDecimal unitCost = request.getAssetCostPrice();
+            if (unitCost == null || unitCost.compareTo(BigDecimal.ZERO) <= 0) {
+                throw new IllegalArgumentException("單價必須大於 0");
+            }
+            BigDecimal addQty = request.getAssetQuantity();
+            BigDecimal oldQty = asset.getQuantity();
+            BigDecimal newQty = oldQty.add(addQty);
+            // 加權平均成本
+            BigDecimal newCostPrice = oldQty.multiply(asset.getCostPrice())
+                    .add(addQty.multiply(unitCost))
+                    .divide(newQty, 8, RoundingMode.HALF_UP);
+            asset.setQuantity(newQty);
+            asset.setCostPrice(newCostPrice);
+            assetRepository.save(asset);
+        } else {
+            String symbol = request.getAssetSymbol().toUpperCase();
+            if (assetRepository.existsByUserIdAndAccountIdAndSymbol(userId, toAccount.getId(), symbol)) {
+                throw new IllegalArgumentException(
+                        "目標帳戶已有代號為「" + symbol + "」的資產，請改用加倉功能");
+            }
+            BigDecimal unitCost = request.getAssetCostPrice();
+            if (unitCost == null || unitCost.compareTo(BigDecimal.ZERO) <= 0) {
+                throw new IllegalArgumentException("單價必須大於 0");
+            }
+            Asset newAsset = new Asset();
+            newAsset.setAccount(toAccount);
+            newAsset.setUser(user);
+            newAsset.setType(request.getAssetType() != null ? request.getAssetType() : AssetType.STOCK);
+            newAsset.setSymbol(symbol);
+            newAsset.setName(request.getAssetName() != null ? request.getAssetName() : symbol);
+            newAsset.setQuantity(request.getAssetQuantity());
+            newAsset.setCostPrice(unitCost);
+            newAsset.setCurrentPrice(unitCost);
+            newAsset.setNote(request.getAssetNote());
+            assetRepository.save(newAsset);
+        }
     }
 
     //Read(單筆)

--- a/backend/src/test/java/com/pocketfolio/backend/service/TransactionServiceTest.java
+++ b/backend/src/test/java/com/pocketfolio/backend/service/TransactionServiceTest.java
@@ -5,6 +5,7 @@ import com.pocketfolio.backend.dto.TransactionResponse;
 import com.pocketfolio.backend.entity.*;
 import com.pocketfolio.backend.exception.ResourceNotFoundException;
 import com.pocketfolio.backend.repository.AccountRepository;
+import com.pocketfolio.backend.repository.AssetRepository;
 import com.pocketfolio.backend.repository.CategoryRepository;
 import com.pocketfolio.backend.repository.TransactionRepository;
 import org.junit.jupiter.api.*;
@@ -38,6 +39,7 @@ class TransactionServiceTest {
     @Mock private TransactionRepository repository;
     @Mock private CategoryRepository categoryRepository;
     @Mock private AccountRepository accountRepository;
+    @Mock private AssetRepository assetRepository;
 
     @InjectMocks private TransactionService service;
 
@@ -68,13 +70,36 @@ class TransactionServiceTest {
     }
 
     private Account accountWith(UUID id, UUID ownerId) {
+        return accountWith(id, ownerId, AccountType.CASH);
+    }
+
+    private Account accountWith(UUID id, UUID ownerId, AccountType type) {
         Account a = new Account();
         a.setId(id);
         a.setName("帳戶-" + id.toString().substring(0, 4));
-        a.setType(AccountType.CASH);
+        a.setType(type);
         a.setInitialBalance(BigDecimal.ZERO);
         a.setUser(userWith(ownerId));
         return a;
+    }
+
+    private Asset assetWith(UUID id, UUID ownerId, Account account) {
+        Asset asset = new Asset();
+        asset.setId(id);
+        asset.setSymbol("2330.TW");
+        asset.setName("台積電");
+        asset.setType(AssetType.STOCK);
+        asset.setQuantity(new BigDecimal("10"));
+        asset.setCostPrice(new BigDecimal("800"));
+        asset.setCurrentPrice(new BigDecimal("800"));
+        asset.setAccount(account);
+        asset.setUser(userWith(ownerId));
+        return asset;
+    }
+
+    private TransactionRequest transferToInvestmentRequest(UUID fromId, UUID toId) {
+        TransactionRequest req = transferRequest(fromId, toId);
+        return req;
     }
 
     private Category categoryWith(UUID id, UUID ownerId) {
@@ -590,6 +615,178 @@ class TransactionServiceTest {
 
             assertThatThrownBy(() -> service.deleteTransaction(unknownId))
                     .isInstanceOf(ResourceNotFoundException.class);
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // createTransfer — 資產連結
+    // ─────────────────────────────────────────────────────────────────────────
+
+    @Nested
+    @DisplayName("createTransfer（資產連結）")
+    class CreateTransferWithAssetLink {
+
+        private UUID fromId;
+        private UUID toId;
+        private Account fromAccount;
+        private Account toAccount;
+
+        @BeforeEach
+        void setUp() {
+            fromId = UUID.randomUUID();
+            toId   = UUID.randomUUID();
+            fromAccount = accountWith(fromId, CURRENT_USER_ID, AccountType.CASH);
+            toAccount   = accountWith(toId,   CURRENT_USER_ID, AccountType.INVESTMENT);
+
+            given(accountRepository.findById(fromId)).willReturn(Optional.of(fromAccount));
+            given(accountRepository.findById(toId)).willReturn(Optional.of(toAccount));
+
+            UUID groupId   = UUID.randomUUID();
+            Transaction inResult  = txEntity(UUID.randomUUID(), TransactionType.TRANSFER_IN,  CURRENT_USER_ID);
+            Transaction outResult = txEntity(UUID.randomUUID(), TransactionType.TRANSFER_OUT, CURRENT_USER_ID);
+            inResult.setTransferGroupId(groupId);
+            outResult.setTransferGroupId(groupId);
+            outResult.setAccount(fromAccount);
+            given(repository.save(any())).willReturn(inResult, outResult);
+        }
+
+        @Test
+        @DisplayName("目標帳戶非 INVESTMENT，不呼叫 assetRepository")
+        void linkAsset_nonInvestmentAccount_noAssetOperation() {
+            Account cashTo = accountWith(toId, CURRENT_USER_ID, AccountType.CASH);
+            given(accountRepository.findById(toId)).willReturn(Optional.of(cashTo));
+
+            TransactionRequest req = transferRequest(fromId, toId);
+            req.setAssetSymbol("2330.TW");
+            req.setAssetQuantity(new BigDecimal("10"));
+
+            service.createTransaction(req);
+
+            then(assetRepository).should(never()).save(any());
+        }
+
+        @Test
+        @DisplayName("帶有 assetId → 加倉已有資產，更新數量與加權平均成本")
+        void linkAsset_withAssetId_updatesQuantityAndWeightedCost() {
+            UUID assetId = UUID.randomUUID();
+            Asset existing = assetWith(assetId, CURRENT_USER_ID, toAccount);
+            // 原本 10 股，成本 800
+            given(assetRepository.findById(assetId)).willReturn(Optional.of(existing));
+            given(assetRepository.save(any(Asset.class))).willReturn(existing);
+
+            TransactionRequest req = transferRequest(fromId, toId);
+            req.setAssetId(assetId);
+            req.setAssetQuantity(new BigDecimal("10"));
+            req.setAssetCostPrice(new BigDecimal("900")); // 單價 900，10 股共 9000
+
+            service.createTransaction(req);
+
+            ArgumentCaptor<Asset> assetCaptor = ArgumentCaptor.forClass(Asset.class);
+            then(assetRepository).should().save(assetCaptor.capture());
+            Asset saved = assetCaptor.getValue();
+
+            assertThat(saved.getQuantity()).isEqualByComparingTo("20");
+            // 加權平均：(10×800 + 10×900) / 20 = 850
+            assertThat(saved.getCostPrice()).isEqualByComparingTo("850");
+        }
+
+        @Test
+        @DisplayName("帶有 assetSymbol → 建立新資產")
+        void linkAsset_withNewSymbol_createsAsset() {
+            given(assetRepository.existsByUserIdAndAccountIdAndSymbol(any(), any(), any())).willReturn(false);
+            given(assetRepository.save(any(Asset.class))).willAnswer(inv -> inv.getArgument(0));
+
+            TransactionRequest req = transferRequest(fromId, toId);
+            req.setAssetSymbol("nvda");
+            req.setAssetName("NVIDIA");
+            req.setAssetType(AssetType.STOCK);
+            req.setAssetQuantity(new BigDecimal("5"));
+            req.setAssetCostPrice(new BigDecimal("1000")); // 單價 1000
+
+            service.createTransaction(req);
+
+            ArgumentCaptor<Asset> assetCaptor = ArgumentCaptor.forClass(Asset.class);
+            then(assetRepository).should().save(assetCaptor.capture());
+            Asset saved = assetCaptor.getValue();
+
+            assertThat(saved.getSymbol()).isEqualTo("NVDA");
+            assertThat(saved.getQuantity()).isEqualByComparingTo("5");
+            assertThat(saved.getCostPrice()).isEqualByComparingTo("1000");
+        }
+
+        @Test
+        @DisplayName("assetQuantity 為 0，拋出 IllegalArgumentException")
+        void linkAsset_zeroQuantity_throws() {
+            TransactionRequest req = transferRequest(fromId, toId);
+            req.setAssetSymbol("NVDA");
+            req.setAssetQuantity(BigDecimal.ZERO);
+
+            assertThatThrownBy(() -> service.createTransaction(req))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("數量");
+        }
+
+        @Test
+        @DisplayName("assetId 不存在，拋出 ResourceNotFoundException")
+        void linkAsset_assetIdNotFound_throws() {
+            UUID unknownAssetId = UUID.randomUUID();
+            given(assetRepository.findById(unknownAssetId)).willReturn(Optional.empty());
+
+            TransactionRequest req = transferRequest(fromId, toId);
+            req.setAssetId(unknownAssetId);
+            req.setAssetQuantity(new BigDecimal("5"));
+
+            assertThatThrownBy(() -> service.createTransaction(req))
+                    .isInstanceOf(ResourceNotFoundException.class);
+        }
+
+        @Test
+        @DisplayName("assetId 屬於他人，拋出 IllegalArgumentException")
+        void linkAsset_assetOwnedByOther_throws() {
+            UUID assetId = UUID.randomUUID();
+            Asset otherAsset = assetWith(assetId, OTHER_USER_ID, toAccount);
+            given(assetRepository.findById(assetId)).willReturn(Optional.of(otherAsset));
+
+            TransactionRequest req = transferRequest(fromId, toId);
+            req.setAssetId(assetId);
+            req.setAssetQuantity(new BigDecimal("5"));
+
+            assertThatThrownBy(() -> service.createTransaction(req))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("無權");
+        }
+
+        @Test
+        @DisplayName("assetId 屬於其他帳戶，拋出 IllegalArgumentException")
+        void linkAsset_assetInDifferentAccount_throws() {
+            UUID assetId = UUID.randomUUID();
+            Account otherAccount = accountWith(UUID.randomUUID(), CURRENT_USER_ID, AccountType.INVESTMENT);
+            Asset wrongAccountAsset = assetWith(assetId, CURRENT_USER_ID, otherAccount);
+            given(assetRepository.findById(assetId)).willReturn(Optional.of(wrongAccountAsset));
+
+            TransactionRequest req = transferRequest(fromId, toId);
+            req.setAssetId(assetId);
+            req.setAssetQuantity(new BigDecimal("5"));
+
+            assertThatThrownBy(() -> service.createTransaction(req))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("不屬於");
+        }
+
+        @Test
+        @DisplayName("新資產代號重複，拋出 IllegalArgumentException")
+        void linkAsset_duplicateSymbol_throws() {
+            given(assetRepository.existsByUserIdAndAccountIdAndSymbol(CURRENT_USER_ID, toId, "NVDA"))
+                    .willReturn(true);
+
+            TransactionRequest req = transferRequest(fromId, toId);
+            req.setAssetSymbol("NVDA");
+            req.setAssetQuantity(new BigDecimal("5"));
+            req.setAssetCostPrice(new BigDecimal("1000"));
+
+            assertThatThrownBy(() -> service.createTransaction(req))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessageContaining("加倉");
         }
     }
 }

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -40,12 +40,24 @@
 
 ## 🔴 高優先級
 
-### 1. 轉帳連結資產（新分支：`feature/transfer-link-asset`）
+### 1. 轉帳連結資產（分支：`feature/transfer-link-asset`）
 **目標：** 在交易頁建立轉帳時，若目標帳戶是投資帳戶，可選擇連結既有資產（加倉）或建立新資產記錄。
-- [ ] 後端：`TransactionRequest` 加入選填 `assetId`（加倉）或新資產欄位
-- [ ] 後端：`TransactionService.createTransfer()` 若目標是 INVESTMENT 帳戶且帶有資產資訊，同步更新 / 建立資產
-- [ ] 前端：目標帳戶選擇後，若是 INVESTMENT 類型，動態顯示資產選擇器（現有資產 + 「新增資產」選項）
-- [ ] 單元測試覆蓋新邏輯
+- [x] 後端：`TransactionRequest` 加入選填 `assetId`（加倉）或新資產欄位
+- [x] 後端：`TransactionService.createTransfer()` 若目標是 INVESTMENT 帳戶且帶有資產資訊，同步更新 / 建立資產
+- [x] 前端：目標帳戶選擇後，若是 INVESTMENT 類型，動態顯示資產選擇器（現有資產 + 「新增資產」選項）
+- [x] 單元測試覆蓋新邏輯（8 個測試，TransactionServiceTest）
+
+### 2. 手動資產輸入（新分支：`feature/manual-asset-entry`）
+**目標：** 讓使用者可以輸入不在已知清單的資產（美股、非前 200 幣等）。
+- [ ] 資產管理頁 + 交易頁資產連結：AutoComplete 下方加「找不到資產？手動輸入」連結，切換為純文字欄位
+- [ ] 兩個頁面同步處理，保持 UX 一致
+
+### 3. 轉帳手續費（新分支：`feature/transfer-fee`）
+**目標：** 建立轉帳時可選填手續費，手續費自動記錄為一筆支出交易，與轉帳共用 `transferGroupId`。
+- [ ] 後端：`TransactionRequest` 加入選填 `fee`（金額）與 `feeCategoryId`
+- [ ] 後端：`TransactionService.createTransfer()` 若 `fee > 0`，額外建立一筆 EXPENSE 交易（同一 `transferGroupId`）
+- [ ] 前端：轉帳表單加手續費開關（預設關閉），開啟後顯示金額輸入與類別選擇（EXPENSE 類別）
+- [ ] 刪除轉帳時，一併刪除同 `transferGroupId` 的手續費記錄
 
 ---
 

--- a/frontend/src/pages/assets/AssetList.tsx
+++ b/frontend/src/pages/assets/AssetList.tsx
@@ -28,11 +28,13 @@ import {
   RiseOutlined,
   FallOutlined,
   DollarOutlined,
+  CheckCircleOutlined,
 } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import { assetApi } from '@/api/asset.api';
 import { accountApi } from '@/api/account.api';
 import { priceApi } from '@/api/price.api';
+
 import { knownAssetApi, type KnownAssetResult, type KnownAssetType } from '@/api/knownAsset.api';
 import { useWebSocketStore } from '@/store/websocketStore';
 import type { Asset, AssetRequest, AssetType } from '@/types/asset.types';
@@ -58,6 +60,9 @@ const AssetList = () => {
   // searchMarket 控制搜哪個清單（STOCK_TW / STOCK_TWO / CRYPTO），與送出的 type 欄位（STOCK / CRYPTO）分開
   const [searchMarket, setSearchMarket] = useState<KnownAssetType>('STOCK_TW');
   const [searchOptions, setSearchOptions] = useState<{ value: string; label: string; data: KnownAssetResult }[]>([]);
+  const [selectedAssetDisplay, setSelectedAssetDisplay] = useState<string | null>(null);
+  const [assetCurrentPrice, setAssetCurrentPrice] = useState<number | null>(null);
+  const [assetCurrentPriceLoading, setAssetCurrentPriceLoading] = useState(false);
   const debounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleAssetSearch = useCallback((keyword: string) => {
@@ -84,13 +89,29 @@ const AssetList = () => {
     }, 300);
   }, [searchMarket]);
 
-  const handleAssetSelect = useCallback((_value: string, option: { value: string; label: string; data: KnownAssetResult }) => {
-    form.setFieldsValue({
-      symbol: option.data.symbol,
-      name: option.data.name,
-    });
+  const handleAssetSelect = useCallback(async (_value: string, option: { value: string; label: string; data: KnownAssetResult }) => {
+    const assetType = form.getFieldValue('type') ?? 'STOCK';
+    form.setFieldsValue({ symbol: option.data.symbol, name: option.data.name });
+    setSelectedAssetDisplay(`${option.data.name}（${option.data.symbol}）`);
     setSearchOptions([]);
+    setAssetCurrentPrice(null);
+    setAssetCurrentPriceLoading(true);
+    try {
+      const data = await priceApi.getPrice(option.data.symbol, assetType);
+      setAssetCurrentPrice(data.price);
+    } catch {
+      // 查不到價格靜默忽略
+    } finally {
+      setAssetCurrentPriceLoading(false);
+    }
   }, [form]);
+
+  const clearSelectedAsset = () => {
+    setSelectedAssetDisplay(null);
+    setAssetCurrentPrice(null);
+    setSearchOptions([]);
+    form.setFieldsValue({ symbol: undefined, name: undefined, _assetSearch: undefined });
+  };
 
   // 載入資料
   useEffect(() => {
@@ -150,6 +171,8 @@ const AssetList = () => {
 
     setSearchMarket('STOCK_TW');
     setSearchOptions([]);
+    setSelectedAssetDisplay(null);
+    setAssetCurrentPrice(null);
     setModalVisible(true);
   };
 
@@ -160,6 +183,8 @@ const AssetList = () => {
     form.setFieldsValue({ ...record, _searchMarket: market });
     setSearchMarket(market);
     setSearchOptions([]);
+    setSelectedAssetDisplay(`${record.name}（${record.symbol}）`);
+    setAssetCurrentPrice(record.currentPrice ?? null);
     setModalVisible(true);
   };
 
@@ -513,6 +538,8 @@ const AssetList = () => {
               });
               setSearchMarket(market);
               setSearchOptions([]);
+              setSelectedAssetDisplay(null);
+              setAssetCurrentPrice(null);
             }}>
               <Radio value="STOCK_TW">台股（上市）</Radio>
               <Radio value="STOCK_TWO">台股（上櫃）</Radio>
@@ -527,16 +554,33 @@ const AssetList = () => {
               if (!form.getFieldValue('symbol')) throw new Error('請選擇一個資產');
             }}]}
           >
-            <AutoComplete
-              options={searchOptions}
-              onSearch={handleAssetSearch}
-              onSelect={handleAssetSelect}
-              placeholder={searchMarket === 'CRYPTO' ? '輸入名稱或代碼，例如：BTC、bitcoin' : '輸入股票代號或名稱，例如：2330、台積電'}
-              allowClear
-              onClear={() => {
-                form.setFieldsValue({ symbol: undefined, name: undefined });
-              }}
-            />
+            {selectedAssetDisplay ? (
+              <Space direction="vertical" size={4} style={{ width: '100%' }}>
+                <Space>
+                  <Tag icon={<CheckCircleOutlined />} color="success" style={{ fontSize: 14, padding: '4px 10px' }}>
+                    {selectedAssetDisplay}
+                  </Tag>
+                  <Button type="link" size="small" onClick={clearSelectedAsset}>重新選擇</Button>
+                </Space>
+                {assetCurrentPriceLoading && (
+                  <span style={{ color: '#8c8c8c', fontSize: 13 }}>查詢當前市價中...</span>
+                )}
+                {!assetCurrentPriceLoading && assetCurrentPrice !== null && (
+                  <span style={{ color: '#1677ff', fontSize: 13 }}>當前市價：{formatCurrency(assetCurrentPrice)}</span>
+                )}
+              </Space>
+            ) : (
+              <AutoComplete
+                options={searchOptions}
+                onSearch={handleAssetSearch}
+                onSelect={handleAssetSelect}
+                placeholder={searchMarket === 'CRYPTO' ? '輸入名稱或代碼，例如：BTC、bitcoin' : '輸入股票代號或名稱，例如：2330、台積電'}
+                allowClear
+                onClear={() => {
+                  form.setFieldsValue({ symbol: undefined, name: undefined });
+                }}
+              />
+            )}
           </Form.Item>
 
           <Form.Item

--- a/frontend/src/pages/transactions/TransactionList.tsx
+++ b/frontend/src/pages/transactions/TransactionList.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import {
   Table,
   Button,
@@ -9,6 +9,8 @@ import {
   InputNumber,
   DatePicker,
   Select,
+  AutoComplete,
+  Radio,
   message,
   Popconfirm,
   Tag,
@@ -20,14 +22,19 @@ import {
   DeleteOutlined,
   SearchOutlined,
   SwapOutlined,
+  CheckCircleOutlined,
 } from '@ant-design/icons';
 import dayjs from 'dayjs';
 import { transactionApi } from '@/api/transaction.api';
 import { categoryApi } from '@/api/category.api';
 import { accountApi } from '@/api/account.api';
+import { assetApi } from '@/api/asset.api';
+import { priceApi } from '@/api/price.api';
+import { knownAssetApi, type KnownAssetResult, type KnownAssetType } from '@/api/knownAsset.api';
 import type { Transaction, TransactionRequest, TransactionType } from '@/types/transaction.types';
 import type { Category } from '@/types/category.types';
 import type { Account } from '@/types/account.types';
+import type { Asset } from '@/types/asset.types';
 import type { ColumnsType } from 'antd/es/table';
 import { formatCurrency, formatDate } from '@/utils/format';
 
@@ -42,6 +49,15 @@ const TransactionList = () => {
   const [modalVisible, setModalVisible] = useState(false);
   const [editingTransaction, setEditingTransaction] = useState<Transaction | null>(null);
   const [selectedType, setSelectedType] = useState<TransactionType>('EXPENSE');
+  const [toAccountIsInvestment, setToAccountIsInvestment] = useState(false);
+  const [investmentAssets, setInvestmentAssets] = useState<Asset[]>([]);
+  const [assetLinkMode, setAssetLinkMode] = useState<'none' | 'existing' | 'new'>('none');
+  const [assetSearchMarket, setAssetSearchMarket] = useState<KnownAssetType>('STOCK_TW');
+  const [assetSearchOptions, setAssetSearchOptions] = useState<{ value: string; label: string; data: KnownAssetResult }[]>([]);
+  const [selectedAssetDisplay, setSelectedAssetDisplay] = useState<string | null>(null);
+  const [assetCurrentPrice, setAssetCurrentPrice] = useState<number | null>(null);
+  const [assetCurrentPriceLoading, setAssetCurrentPriceLoading] = useState(false);
+  const assetDebounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [form] = Form.useForm();
 
   // 篩選條件
@@ -92,9 +108,92 @@ const TransactionList = () => {
     }
   };
 
+  const resetAssetLinkState = () => {
+    setToAccountIsInvestment(false);
+    setInvestmentAssets([]);
+    setAssetLinkMode('none');
+    setAssetSearchMarket('STOCK_TW');
+    setAssetSearchOptions([]);
+    setSelectedAssetDisplay(null);
+    setAssetCurrentPrice(null);
+  };
+
+  const clearSelectedAsset = () => {
+    setSelectedAssetDisplay(null);
+    setAssetCurrentPrice(null);
+    setAssetSearchOptions([]);
+    form.setFieldsValue({ assetSymbol: undefined, assetName: undefined, _assetSearchInput: undefined });
+  };
+
+  const recalcTransferAmount = () => {
+    const qty: number | undefined = form.getFieldValue('assetQuantity');
+    const price: number | undefined = form.getFieldValue('assetCostPrice');
+    if (qty && price && qty > 0 && price > 0) {
+      form.setFieldValue('amount', parseFloat((qty * price).toFixed(2)));
+    }
+  };
+
+  const handleAssetSymbolSearch = useCallback((keyword: string) => {
+    if (keyword.length < 1) { setAssetSearchOptions([]); return; }
+    if (assetDebounceTimer.current) clearTimeout(assetDebounceTimer.current);
+    assetDebounceTimer.current = setTimeout(async () => {
+      try {
+        const results = await knownAssetApi.search(assetSearchMarket, keyword);
+        setAssetSearchOptions(results.map((r) => ({
+          value: r.symbol,
+          label: r.marketCapRank
+            ? `${r.displayCode}  ${r.name}  #${r.marketCapRank}`
+            : `${r.displayCode}  ${r.name}`,
+          data: r,
+        })));
+      } catch { /* 靜默忽略 */ }
+    }, 300);
+  }, [assetSearchMarket]);
+
+  const handleAssetSymbolSelect = useCallback(async (_value: string, option: { value: string; label: string; data: KnownAssetResult }) => {
+    const assetType = form.getFieldValue('assetType') ?? 'STOCK';
+    form.setFieldsValue({ assetSymbol: option.data.symbol, assetName: option.data.name });
+    setSelectedAssetDisplay(`${option.data.name}（${option.data.symbol}）`);
+    setAssetSearchOptions([]);
+    setAssetCurrentPrice(null);
+    setAssetCurrentPriceLoading(true);
+    try {
+      const data = await priceApi.getPrice(option.data.symbol, assetType);
+      setAssetCurrentPrice(data.price);
+    } catch {
+      // 查不到價格不影響主流程，靜默忽略
+    } finally {
+      setAssetCurrentPriceLoading(false);
+    }
+  }, [form]);
+
+  const handleToAccountChange = async (accountId: string) => {
+    const account = accounts.find((a) => a.id === accountId);
+    if (account?.type === 'INVESTMENT') {
+      setToAccountIsInvestment(true);
+      try {
+        const assets = await assetApi.getAccountAssets(accountId);
+        setInvestmentAssets(assets);
+      } catch {
+        setInvestmentAssets([]);
+      }
+    } else {
+      setToAccountIsInvestment(false);
+      setInvestmentAssets([]);
+    }
+    setAssetLinkMode('none');
+    form.setFieldValue('assetId', undefined);
+    form.setFieldValue('assetSymbol', undefined);
+    form.setFieldValue('assetName', undefined);
+    form.setFieldValue('assetQuantity', undefined);
+    form.setFieldValue('_assetSearchInput', undefined);
+    form.setFieldValue('_assetSearchMarket', 'STOCK_TW');
+  };
+
   const handleCreate = () => {
     setEditingTransaction(null);
     setSelectedType('EXPENSE');
+    resetAssetLinkState();
     form.resetFields();
     form.setFieldsValue({ type: 'EXPENSE', date: dayjs() });
     setModalVisible(true);
@@ -126,6 +225,18 @@ const TransactionList = () => {
       const requestData: TransactionRequest = {
         ...values,
         date: values.date.format('YYYY-MM-DD'),
+        // 不連結資產時清除相關欄位
+        ...(assetLinkMode === 'none' && {
+          assetId: undefined,
+          assetSymbol: undefined,
+          assetName: undefined,
+          assetType: undefined,
+          assetQuantity: undefined,
+          assetCostPrice: undefined,
+          assetNote: undefined,
+        }),
+        _assetSearchMarket: undefined,
+        _assetSearchInput: undefined,
       };
 
       if (editingTransaction) {
@@ -348,6 +459,7 @@ const TransactionList = () => {
                 setSelectedType(v);
                 form.setFieldValue('categoryId', undefined);
                 form.setFieldValue('toAccountId', undefined);
+                resetAssetLinkState();
               }}
               disabled={!!editingTransaction}
             >
@@ -406,19 +518,180 @@ const TransactionList = () => {
               name="toAccountId"
               rules={[{ required: true, message: '請選擇目標帳戶' }]}
             >
-              <Select placeholder="請選擇目標帳戶">
+              <Select placeholder="請選擇目標帳戶" onChange={handleToAccountChange}>
                 {accounts.map((acc) => (
                   <Select.Option key={acc.id} value={acc.id}>
                     {acc.name}
+                    {acc.type === 'INVESTMENT' && (
+                      <span style={{ color: '#1677ff', marginLeft: 6, fontSize: 12 }}>投資</span>
+                    )}
                   </Select.Option>
                 ))}
               </Select>
             </Form.Item>
           )}
 
+          {/* 資產連結（目標為投資帳戶時顯示） */}
+          {isTransfer && toAccountIsInvestment && (
+            <>
+              <Form.Item label="連結資產">
+                <Select
+                  value={assetLinkMode}
+                  onChange={(v) => setAssetLinkMode(v)}
+                >
+                  <Select.Option value="none">不連結資產</Select.Option>
+                  <Select.Option value="existing">加倉已有資產</Select.Option>
+                  <Select.Option value="new">建立新資產</Select.Option>
+                </Select>
+              </Form.Item>
+
+              {assetLinkMode === 'existing' && (
+                <>
+                  <Form.Item
+                    label="選擇資產"
+                    name="assetId"
+                    rules={[{ required: true, message: '請選擇資產' }]}
+                  >
+                    <Select
+                      placeholder="請選擇要加倉的資產"
+                      onChange={(id: string) => {
+                        const asset = investmentAssets.find((a) => a.id === id);
+                        setAssetCurrentPrice(asset?.currentPrice ?? null);
+                      }}
+                    >
+                      {investmentAssets.map((a) => (
+                        <Select.Option key={a.id} value={a.id}>
+                          {a.name}（{a.symbol}）持有 {a.quantity} 股
+                        </Select.Option>
+                      ))}
+                    </Select>
+                  </Form.Item>
+                  {assetCurrentPrice !== null && (
+                    <div style={{ marginTop: -16, marginBottom: 16, color: '#1677ff', fontSize: 13 }}>
+                      當前市價：{formatCurrency(assetCurrentPrice)}
+                    </div>
+                  )}
+                  <Form.Item
+                    label="加倉數量"
+                    name="assetQuantity"
+                    rules={[
+                      { required: true, message: '請輸入加倉數量' },
+                      { type: 'number', min: 0.00000001, message: '數量必須大於 0' },
+                    ]}
+                  >
+                    <InputNumber style={{ width: '100%' }} placeholder="新增持有數量" min={0} onChange={recalcTransferAmount} />
+                  </Form.Item>
+                  <Form.Item
+                    label="單價"
+                    name="assetCostPrice"
+                    rules={[
+                      { required: true, message: '請輸入單價' },
+                      { type: 'number', min: 0.00000001, message: '單價必須大於 0' },
+                    ]}
+                  >
+                    <InputNumber style={{ width: '100%' }} placeholder="這批買入的每單位價格" min={0} precision={2} onChange={recalcTransferAmount} />
+                  </Form.Item>
+                </>
+              )}
+
+              {assetLinkMode === 'new' && (
+                <>
+                  {/* hidden fields 儲存實際送出的值 */}
+                  <Form.Item name="assetSymbol" hidden><AutoComplete /></Form.Item>
+                  <Form.Item name="assetName" hidden><AutoComplete /></Form.Item>
+                  <Form.Item name="assetType" initialValue="STOCK" hidden><AutoComplete /></Form.Item>
+
+                  <Form.Item
+                    label="資產市場"
+                    name="_assetSearchMarket"
+                    initialValue="STOCK_TW"
+                  >
+                    <Radio.Group onChange={(e) => {
+                      const market: KnownAssetType = e.target.value;
+                      form.setFieldsValue({
+                        assetType: market === 'CRYPTO' ? 'CRYPTO' : 'STOCK',
+                        assetSymbol: undefined,
+                        assetName: undefined,
+                        _assetSearchInput: undefined,
+                      });
+                      setAssetSearchMarket(market);
+                      setAssetSearchOptions([]);
+                      setSelectedAssetDisplay(null);
+                      setAssetCurrentPrice(null);
+                    }}>
+                      <Radio value="STOCK_TW">台股（上市）</Radio>
+                      <Radio value="STOCK_TWO">台股（上櫃）</Radio>
+                      <Radio value="CRYPTO">加密貨幣</Radio>
+                    </Radio.Group>
+                  </Form.Item>
+
+                  <Form.Item
+                    label="搜尋資產"
+                    name="_assetSearchInput"
+                    rules={[{ validator: async () => {
+                      if (!form.getFieldValue('assetSymbol')) throw new Error('請選擇一個資產');
+                    }}]}
+                  >
+                    {selectedAssetDisplay ? (
+                      <Space direction="vertical" size={4} style={{ width: '100%' }}>
+                        <Space>
+                          <Tag icon={<CheckCircleOutlined />} color="success" style={{ fontSize: 14, padding: '4px 10px' }}>
+                            {selectedAssetDisplay}
+                          </Tag>
+                          <Button type="link" size="small" onClick={clearSelectedAsset}>
+                            重新選擇
+                          </Button>
+                        </Space>
+                        {assetCurrentPriceLoading && (
+                          <span style={{ color: '#8c8c8c', fontSize: 13 }}>查詢當前市價中...</span>
+                        )}
+                        {!assetCurrentPriceLoading && assetCurrentPrice !== null && (
+                          <span style={{ color: '#1677ff', fontSize: 13 }}>
+                            當前市價：{formatCurrency(assetCurrentPrice)}
+                          </span>
+                        )}
+                      </Space>
+                    ) : (
+                      <AutoComplete
+                        options={assetSearchOptions}
+                        onSearch={handleAssetSymbolSearch}
+                        onSelect={handleAssetSymbolSelect}
+                        placeholder={assetSearchMarket === 'CRYPTO' ? '輸入名稱或代碼，例如：BTC、bitcoin' : '輸入股票代號或名稱，例如：2330、台積電'}
+                        allowClear
+                        onClear={() => form.setFieldsValue({ assetSymbol: undefined, assetName: undefined })}
+                      />
+                    )}
+                  </Form.Item>
+
+                  <Form.Item
+                    label="數量"
+                    name="assetQuantity"
+                    rules={[
+                      { required: true, message: '請輸入數量' },
+                      { type: 'number', min: 0.00000001, message: '數量必須大於 0' },
+                    ]}
+                  >
+                    <InputNumber style={{ width: '100%' }} placeholder="持有數量" min={0} onChange={recalcTransferAmount} />
+                  </Form.Item>
+                  <Form.Item
+                    label="單價"
+                    name="assetCostPrice"
+                    rules={[
+                      { required: true, message: '請輸入單價' },
+                      { type: 'number', min: 0.00000001, message: '單價必須大於 0' },
+                    ]}
+                  >
+                    <InputNumber style={{ width: '100%' }} placeholder="買入的每單位價格" min={0} precision={2} onChange={recalcTransferAmount} />
+                  </Form.Item>
+                </>
+              )}
+            </>
+          )}
+
           <Form.Item
             label="金額"
             name="amount"
+            extra={assetLinkMode !== 'none' ? '由數量 × 單價自動計算' : undefined}
             rules={[
               { required: true, message: '請輸入金額' },
               { type: 'number', min: 0.01, message: '金額必須大於 0' },
@@ -429,6 +702,7 @@ const TransactionList = () => {
               placeholder="請輸入金額"
               precision={2}
               min={0}
+              disabled={assetLinkMode !== 'none'}
             />
           </Form.Item>
 

--- a/frontend/src/types/transaction.types.ts
+++ b/frontend/src/types/transaction.types.ts
@@ -27,4 +27,12 @@ export interface TransactionRequest {
   categoryId?: string;
   accountId?: string;
   toAccountId?: string;
+  // 資產連結（TRANSFER_OUT 轉入 INVESTMENT 帳戶時選填）
+  assetId?: string;
+  assetType?: 'STOCK' | 'CRYPTO' | 'FUND' | 'BOND';
+  assetSymbol?: string;
+  assetName?: string;
+  assetQuantity?: number;
+  assetCostPrice?: number;
+  assetNote?: string;
 }


### PR DESCRIPTION
## Summary

- **Backend**: `TransactionRequest` 新增 7 個選填資產欄位；`TransactionService.linkAssetIfNeeded()` 支援加倉（加權平均成本）與建立新資產兩種路徑
- **Frontend (TransactionList)**: 目標帳戶為 INVESTMENT 時動態顯示資產連結區塊；金額欄位改為數量 × 單價自動計算並鎖定；AutoComplete 選取後以確認 Tag 保護，防止誤改；顯示當前市價
- **Frontend (AssetList)**: 同樣套用 AutoComplete 確認保護與當前市價顯示；編輯時預填已確認 Tag
- **Tests**: 新增 8 個 `TransactionServiceTest` 案例，涵蓋加倉、新資產建立、及各種錯誤路徑

## Test plan

- [x] 建立轉帳到 INVESTMENT 帳戶 → 應顯示資產連結區塊
- [x] 選擇「加倉」既有資產 → 填入數量與單價後，金額欄位自動計算並鎖定
- [x] 提交後確認資產數量增加、成本以加權平均更新
- [x] 選擇「新增資產」→ 搜尋並確認資產（確認 Tag 出現）→ 填入數量與單價 → 提交
- [x] 提交後確認新資產建立、帳戶餘額扣款
- [x] 轉帳到非 INVESTMENT 帳戶 → 不應顯示資產連結區塊
- [x] 資產管理頁：搜尋資產 → 選取後顯示確認 Tag + 當前市價
- [x] 資產管理頁：點「重新選擇」→ 回到 AutoComplete 輸入狀態
- [x] `./mvnw test` 全部通過（35 個 TransactionServiceTest）

🤖 Generated with [Claude Code](https://claude.com/claude-code)