### PR TITLE
feat(asset): track price currency and separate TWD/USD stats

### DIFF
--- a/backend/src/main/java/com/pocketfolio/backend/dto/AssetResponse.java
+++ b/backend/src/main/java/com/pocketfolio/backend/dto/AssetResponse.java
@@ -24,5 +24,6 @@ public class AssetResponse {
     private BigDecimal marketValue;       // 市值
     private BigDecimal profitLoss;        // 損益金額
     private BigDecimal profitLossPercent; // 損益百分比
+    private String priceCurrency;         // 市價幣別：TWD / USD
     private String note;
 }

--- a/backend/src/main/java/com/pocketfolio/backend/dto/PriceData.java
+++ b/backend/src/main/java/com/pocketfolio/backend/dto/PriceData.java
@@ -20,6 +20,7 @@ public class PriceData implements Serializable {
 
     private String symbol;           // 代號
     private BigDecimal price;        // 價格
+    private String currency;         // 幣別：USD（加密貨幣）/ TWD（台股）
     private LocalDateTime updateTime; // 更新時間
     private String source;           // 資料來源（COINGECKO / YAHOO）
 

--- a/backend/src/main/java/com/pocketfolio/backend/entity/Asset.java
+++ b/backend/src/main/java/com/pocketfolio/backend/entity/Asset.java
@@ -46,6 +46,9 @@ public class Asset {
 
     private String note;  // 備註
 
+    @Column(length = 3)
+    private String priceCurrency;  // 市價幣別：TWD（台股）/ USD（加密貨幣）
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;

--- a/backend/src/main/java/com/pocketfolio/backend/service/AssetService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/AssetService.java
@@ -60,6 +60,7 @@ public class AssetService {
         asset.setQuantity(request.getQuantity());
         asset.setCostPrice(request.getCostPrice());
         asset.setCurrentPrice(request.getCostPrice());  // 初始時用成本價
+        asset.setPriceCurrency(request.getType() == AssetType.CRYPTO ? "USD" : "TWD");
         asset.setNote(request.getNote());
 
         // 設定用戶關聯
@@ -223,6 +224,7 @@ public class AssetService {
                 .marketValue(asset.getMarketValue())
                 .profitLoss(asset.getProfitLoss())
                 .profitLossPercent(asset.getProfitLossPercent())
+                .priceCurrency(asset.getPriceCurrency())
                 .note(asset.getNote())
                 .build();
     }

--- a/backend/src/main/java/com/pocketfolio/backend/service/PriceService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/PriceService.java
@@ -93,6 +93,9 @@ public class PriceService {
         // 更新資產價格
         asset.setCurrentPrice(newPrice);
         asset.setLastPriceUpdate(LocalDateTime.now());
+        if (priceData.getCurrency() != null) {
+            asset.setPriceCurrency(priceData.getCurrency());
+        }
         assetRepository.save(asset);
 
         log.info("資產價格已更新: {} ${} -> ${} ({}{}) ",

--- a/backend/src/main/java/com/pocketfolio/backend/service/TransactionService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/TransactionService.java
@@ -167,15 +167,17 @@ public class TransactionService {
             if (unitCost == null || unitCost.compareTo(BigDecimal.ZERO) <= 0) {
                 throw new IllegalArgumentException("單價必須大於 0");
             }
+            AssetType newType = request.getAssetType() != null ? request.getAssetType() : AssetType.STOCK;
             Asset newAsset = new Asset();
             newAsset.setAccount(toAccount);
             newAsset.setUser(user);
-            newAsset.setType(request.getAssetType() != null ? request.getAssetType() : AssetType.STOCK);
+            newAsset.setType(newType);
             newAsset.setSymbol(symbol);
             newAsset.setName(request.getAssetName() != null ? request.getAssetName() : symbol);
             newAsset.setQuantity(request.getAssetQuantity());
             newAsset.setCostPrice(unitCost);
             newAsset.setCurrentPrice(unitCost);
+            newAsset.setPriceCurrency(newType == AssetType.CRYPTO ? "USD" : "TWD");
             newAsset.setNote(request.getAssetNote());
             assetRepository.save(newAsset);
         }

--- a/backend/src/main/java/com/pocketfolio/backend/service/external/CoinGeckoService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/external/CoinGeckoService.java
@@ -52,6 +52,7 @@ public class CoinGeckoService {
                 return PriceData.builder()
                         .symbol(id)
                         .price(price)
+                        .currency("USD")
                         .updateTime(LocalDateTime.now())
                         .source("CoinGecko")
                         .build();

--- a/backend/src/main/java/com/pocketfolio/backend/service/external/YahooFinanceService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/external/YahooFinanceService.java
@@ -52,6 +52,7 @@ public class YahooFinanceService {
                 return PriceData.builder()
                         .symbol(symbol)
                         .price(price)
+                        .currency("TWD")
                         .updateTime(LocalDateTime.now())
                         .source("YAHOO_FINANCE")
                         .build();

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,6 +1,6 @@
 # PocketFolio 待辦事項
 
-更新時間：2026-04-19
+更新時間：2026-05-02
 
 ---
 
@@ -47,7 +47,16 @@
 - [x] 前端：目標帳戶選擇後，若是 INVESTMENT 類型，動態顯示資產選擇器（現有資產 + 「新增資產」選項）
 - [x] 單元測試覆蓋新邏輯（8 個測試，TransactionServiceTest）
 
-### 2. 手動資產輸入（新分支：`feature/manual-asset-entry`）
+### 2. 加密貨幣幣別不一致（[#15](https://github.com/WIse4466/pocketfolio/issues/15)）（分支：`feature/asset-price-currency`）
+**問題：** CoinGecko 回傳 USD 價格直接存入 `asset.current_price`，與台股 TWD 價格混算，導致資產頁統計數字錯誤。
+- [x] `Asset` entity 加 `priceCurrency` 欄位（CRYPTO → USD，STOCK → TWD）
+- [x] `PriceService` 更新價格時寫入 `priceCurrency`；`AssetService` / `TransactionService` 建立資產時依 type 初始化
+- [x] 前端 AssetList：統計卡片按幣別分組（台股 TWD / 加密貨幣 USD），不混算
+- [x] 前端 AssetList 表格：成本價、當前價格、市值欄動態顯示幣別 label
+- [x] 前端表單（AssetList、TransactionList）：成本/單價欄位顯示幣別提示（USD/TWD）
+- [ ] （長期）引入匯率換算，統一以 TWD 加總顯示投資組合總值（`feature/exchange-rate`）
+
+### 3. 手動資產輸入（新分支：`feature/manual-asset-entry`）
 **目標：** 讓使用者可以輸入不在已知清單的資產（美股、非前 200 幣等）。
 - [ ] 資產管理頁 + 交易頁資產連結：AutoComplete 下方加「找不到資產？手動輸入」連結，切換為純文字欄位
 - [ ] 兩個頁面同步處理，保持 UX 一致

--- a/frontend/src/pages/assets/AssetList.tsx
+++ b/frontend/src/pages/assets/AssetList.tsx
@@ -247,11 +247,19 @@ const AssetList = () => {
     }
   };
 
-  // 計算統計資料
-  const totalMarketValue = assets.reduce((sum, asset) => sum + asset.marketValue, 0);
-  const totalCost = assets.reduce((sum, asset) => sum + asset.costPrice * asset.quantity, 0);
-  const totalProfitLoss = totalMarketValue - totalCost;
-  const totalProfitLossPercent = totalCost > 0 ? (totalProfitLoss / totalCost) * 100 : 0;
+  // 計算統計資料（台股 TWD / 加密貨幣 USD 分開計算，不混合幣別）
+  const twdAssets = assets.filter((a) => (a.priceCurrency ?? 'TWD') === 'TWD');
+  const usdAssets = assets.filter((a) => a.priceCurrency === 'USD');
+
+  const twdMarketValue = twdAssets.reduce((sum, a) => sum + a.marketValue, 0);
+  const twdCost = twdAssets.reduce((sum, a) => sum + a.costPrice * a.quantity, 0);
+  const twdProfitLoss = twdMarketValue - twdCost;
+  const twdProfitLossPercent = twdCost > 0 ? (twdProfitLoss / twdCost) * 100 : 0;
+
+  const usdMarketValue = usdAssets.reduce((sum, a) => sum + a.marketValue, 0);
+  const usdCost = usdAssets.reduce((sum, a) => sum + a.costPrice * a.quantity, 0);
+  const usdProfitLoss = usdMarketValue - usdCost;
+  const usdProfitLossPercent = usdCost > 0 ? (usdProfitLoss / usdCost) * 100 : 0;
 
   // 表格欄位
   const columns: ColumnsType<Asset> = [
@@ -291,19 +299,21 @@ const AssetList = () => {
       title: '成本價',
       dataIndex: 'costPrice',
       key: 'costPrice',
-      width: 100,
+      width: 110,
       align: 'right',
-      render: (price: number) => formatCurrency(price),
+      render: (price: number, record: Asset) => (
+        <span>{formatCurrency(price)} <Text type="secondary" style={{ fontSize: 11 }}>{record.priceCurrency ?? 'TWD'}</Text></span>
+      ),
     },
     {
       title: '當前價格',
       dataIndex: 'currentPrice',
       key: 'currentPrice',
-      width: 120,
+      width: 130,
       align: 'right',
       render: (price: number, record: Asset) => (
         <Tooltip title={`更新時間: ${dayjs(record.lastPriceUpdate).format('MM/DD HH:mm')}`}>
-          <span>{formatCurrency(price)}</span>
+          <span>{formatCurrency(price)} <Text type="secondary" style={{ fontSize: 11 }}>{record.priceCurrency ?? 'TWD'}</Text></span>
         </Tooltip>
       ),
     },
@@ -311,10 +321,10 @@ const AssetList = () => {
       title: '市值',
       dataIndex: 'marketValue',
       key: 'marketValue',
-      width: 120,
+      width: 130,
       align: 'right',
-      render: (value: number) => (
-        <span style={{ fontWeight: 'bold' }}>{formatCurrency(value)}</span>
+      render: (value: number, record: Asset) => (
+        <span style={{ fontWeight: 'bold' }}>{formatCurrency(value)} <Text type="secondary" style={{ fontSize: 11 }}>{record.priceCurrency ?? 'TWD'}</Text></span>
       ),
       sorter: (a, b) => a.marketValue - b.marketValue,
     },
@@ -419,63 +429,94 @@ const AssetList = () => {
             ))}
           </Select>
 
-          {/* 統計卡片 */}
-          <Row gutter={16} style={{ marginBottom: 16 }}>
-            <Col xs={24} sm={12} lg={6}>
-              <Card>
-                <Statistic
-                  title="總市值"
-                  value={totalMarketValue}
-                  precision={0}
-                  prefix={<DollarOutlined />}
-                  suffix="TWD"
-                />
-              </Card>
-            </Col>
+          {/* 統計卡片 — 台股（TWD）*/}
+          {twdAssets.length > 0 && (
+            <>
+              <Text type="secondary" style={{ fontSize: 12, marginBottom: 4, display: 'block' }}>台股（TWD）</Text>
+              <Row gutter={16} style={{ marginBottom: 8 }}>
+                <Col xs={24} sm={12} lg={6}>
+                  <Card size="small">
+                    <Statistic title="市值" value={twdMarketValue} precision={0} prefix={<DollarOutlined />} suffix="TWD" />
+                  </Card>
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <Card size="small">
+                    <Statistic title="成本" value={twdCost} precision={0} prefix="$" suffix="TWD" />
+                  </Card>
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <Card size="small">
+                    <Statistic
+                      title="損益"
+                      value={twdProfitLoss}
+                      precision={0}
+                      valueStyle={{ color: twdProfitLoss >= 0 ? '#3f8600' : '#cf1322' }}
+                      prefix={twdProfitLoss >= 0 ? <RiseOutlined /> : <FallOutlined />}
+                      suffix="TWD"
+                    />
+                  </Card>
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <Card size="small">
+                    <Statistic
+                      title="報酬率"
+                      value={twdProfitLossPercent}
+                      precision={2}
+                      valueStyle={{ color: twdProfitLoss >= 0 ? '#3f8600' : '#cf1322' }}
+                      suffix="%"
+                    />
+                    <Progress percent={Math.abs(twdProfitLossPercent)} showInfo={false} strokeColor={twdProfitLoss >= 0 ? '#52c41a' : '#ff4d4f'} size="small" />
+                  </Card>
+                </Col>
+              </Row>
+            </>
+          )}
 
-            <Col xs={24} sm={12} lg={6}>
-              <Card>
-                <Statistic
-                  title="總成本"
-                  value={totalCost}
-                  precision={0}
-                  prefix="$"
-                  suffix="TWD"
-                />
-              </Card>
-            </Col>
+          {/* 統計卡片 — 加密貨幣（USD）*/}
+          {usdAssets.length > 0 && (
+            <>
+              <Text type="secondary" style={{ fontSize: 12, marginBottom: 4, display: 'block' }}>加密貨幣（USD）</Text>
+              <Row gutter={16} style={{ marginBottom: 16 }}>
+                <Col xs={24} sm={12} lg={6}>
+                  <Card size="small">
+                    <Statistic title="市值" value={usdMarketValue} precision={2} prefix={<DollarOutlined />} suffix="USD" />
+                  </Card>
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <Card size="small">
+                    <Statistic title="成本" value={usdCost} precision={2} prefix="$" suffix="USD" />
+                  </Card>
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <Card size="small">
+                    <Statistic
+                      title="損益"
+                      value={usdProfitLoss}
+                      precision={2}
+                      valueStyle={{ color: usdProfitLoss >= 0 ? '#3f8600' : '#cf1322' }}
+                      prefix={usdProfitLoss >= 0 ? <RiseOutlined /> : <FallOutlined />}
+                      suffix="USD"
+                    />
+                  </Card>
+                </Col>
+                <Col xs={24} sm={12} lg={6}>
+                  <Card size="small">
+                    <Statistic
+                      title="報酬率"
+                      value={usdProfitLossPercent}
+                      precision={2}
+                      valueStyle={{ color: usdProfitLoss >= 0 ? '#3f8600' : '#cf1322' }}
+                      suffix="%"
+                    />
+                    <Progress percent={Math.abs(usdProfitLossPercent)} showInfo={false} strokeColor={usdProfitLoss >= 0 ? '#52c41a' : '#ff4d4f'} size="small" />
+                  </Card>
+                </Col>
+              </Row>
+            </>
+          )}
 
-            <Col xs={24} sm={12} lg={6}>
-              <Card>
-                <Statistic
-                  title="總損益"
-                  value={totalProfitLoss}
-                  precision={0}
-                  valueStyle={{ color: totalProfitLoss >= 0 ? '#3f8600' : '#cf1322' }}
-                  prefix={totalProfitLoss >= 0 ? <RiseOutlined /> : <FallOutlined />}
-                  suffix="TWD"
-                />
-              </Card>
-            </Col>
-
-            <Col xs={24} sm={12} lg={6}>
-              <Card>
-                <Statistic
-                  title="報酬率"
-                  value={totalProfitLossPercent}
-                  precision={2}
-                  valueStyle={{ color: totalProfitLoss >= 0 ? '#3f8600' : '#cf1322' }}
-                  suffix="%"
-                />
-                <Progress
-                  percent={Math.abs(totalProfitLossPercent)}
-                  showInfo={false}
-                  strokeColor={totalProfitLoss >= 0 ? '#52c41a' : '#ff4d4f'}
-                  size="small"
-                />
-              </Card>
-            </Col>
-          </Row>
+          {/* 只有台股或只有加密貨幣時補間距 */}
+          {twdAssets.length === 0 && usdAssets.length === 0 && <div style={{ marginBottom: 16 }} />}
 
           {/* 表格 */}
           <Table
@@ -600,18 +641,20 @@ const AssetList = () => {
           </Form.Item>
 
           <Form.Item
-            label="成本價格"
+            label={`成本價格（${searchMarket === 'CRYPTO' ? 'USD' : 'TWD'}）`}
             name="costPrice"
             rules={[
               { required: true, message: '請輸入成本價格' },
               { type: 'number', min: 0.01, message: '價格必須大於 0' },
             ]}
+            extra={searchMarket === 'CRYPTO' ? '加密貨幣以美元（USD）計價' : undefined}
           >
             <InputNumber
               style={{ width: '100%' }}
               placeholder="請輸入購買時的價格"
               precision={2}
               min={0}
+              addonAfter={searchMarket === 'CRYPTO' ? 'USD' : 'TWD'}
             />
           </Form.Item>
 

--- a/frontend/src/pages/transactions/TransactionList.tsx
+++ b/frontend/src/pages/transactions/TransactionList.tsx
@@ -57,6 +57,7 @@ const TransactionList = () => {
   const [selectedAssetDisplay, setSelectedAssetDisplay] = useState<string | null>(null);
   const [assetCurrentPrice, setAssetCurrentPrice] = useState<number | null>(null);
   const [assetCurrentPriceLoading, setAssetCurrentPriceLoading] = useState(false);
+  const [assetPriceCurrency, setAssetPriceCurrency] = useState<'TWD' | 'USD'>('TWD');
   const assetDebounceTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [form] = Form.useForm();
 
@@ -116,6 +117,7 @@ const TransactionList = () => {
     setAssetSearchOptions([]);
     setSelectedAssetDisplay(null);
     setAssetCurrentPrice(null);
+    setAssetPriceCurrency('TWD');
   };
 
   const clearSelectedAsset = () => {
@@ -557,6 +559,7 @@ const TransactionList = () => {
                       onChange={(id: string) => {
                         const asset = investmentAssets.find((a) => a.id === id);
                         setAssetCurrentPrice(asset?.currentPrice ?? null);
+                        setAssetPriceCurrency(asset?.priceCurrency === 'USD' ? 'USD' : 'TWD');
                       }}
                     >
                       {investmentAssets.map((a) => (
@@ -582,14 +585,14 @@ const TransactionList = () => {
                     <InputNumber style={{ width: '100%' }} placeholder="新增持有數量" min={0} onChange={recalcTransferAmount} />
                   </Form.Item>
                   <Form.Item
-                    label="單價"
+                    label={`單價（${assetPriceCurrency}）`}
                     name="assetCostPrice"
                     rules={[
                       { required: true, message: '請輸入單價' },
                       { type: 'number', min: 0.00000001, message: '單價必須大於 0' },
                     ]}
                   >
-                    <InputNumber style={{ width: '100%' }} placeholder="這批買入的每單位價格" min={0} precision={2} onChange={recalcTransferAmount} />
+                    <InputNumber style={{ width: '100%' }} placeholder="這批買入的每單位價格" min={0} precision={2} onChange={recalcTransferAmount} addonAfter={assetPriceCurrency} />
                   </Form.Item>
                 </>
               )}
@@ -618,6 +621,7 @@ const TransactionList = () => {
                       setAssetSearchOptions([]);
                       setSelectedAssetDisplay(null);
                       setAssetCurrentPrice(null);
+                      setAssetPriceCurrency(market === 'CRYPTO' ? 'USD' : 'TWD');
                     }}>
                       <Radio value="STOCK_TW">台股（上市）</Radio>
                       <Radio value="STOCK_TWO">台股（上櫃）</Radio>
@@ -674,14 +678,14 @@ const TransactionList = () => {
                     <InputNumber style={{ width: '100%' }} placeholder="持有數量" min={0} onChange={recalcTransferAmount} />
                   </Form.Item>
                   <Form.Item
-                    label="單價"
+                    label={`單價（${assetPriceCurrency}）`}
                     name="assetCostPrice"
                     rules={[
                       { required: true, message: '請輸入單價' },
                       { type: 'number', min: 0.00000001, message: '單價必須大於 0' },
                     ]}
                   >
-                    <InputNumber style={{ width: '100%' }} placeholder="買入的每單位價格" min={0} precision={2} onChange={recalcTransferAmount} />
+                    <InputNumber style={{ width: '100%' }} placeholder="買入的每單位價格" min={0} precision={2} onChange={recalcTransferAmount} addonAfter={assetPriceCurrency} />
                   </Form.Item>
                 </>
               )}

--- a/frontend/src/types/asset.types.ts
+++ b/frontend/src/types/asset.types.ts
@@ -13,6 +13,7 @@ export interface Asset {
   profitLoss: number;
   profitLossPercent: number;
   lastPriceUpdate?: string;
+  priceCurrency?: string;  // 市價幣別：TWD（台股）/ USD（加密貨幣）
 }
 
 export interface AssetRequest {


### PR DESCRIPTION
## Summary

- **後端**: `Asset` entity 新增 `priceCurrency` 欄位（CRYPTO → `"USD"`，STOCK → `"TWD"`）；`PriceData` DTO 新增 `currency` 欄位，`CoinGeckoService` 填 `"USD"`，`YahooFinanceService` 填 `"TWD"`；`PriceService` 更新價格時同步寫入 `priceCurrency`；`AssetService` / `TransactionService` 建立資產時依 type 初始化
- **前端 AssetList 統計卡片**: 台股（TWD）和加密貨幣（USD）分組顯示，不再跨幣別混算市值、成本、損益
- **前端 AssetList 表格**: 成本價、當前價格、市值欄各自動態顯示 USD/TWD label
- **前端表單**: AssetList 成本價欄位、TransactionList 單價欄位旁顯示幣別（USD/TWD）
- **TODO**: 標記 Issue #15 完成；新增長期項目 `feature/exchange-rate`（匯率換算，統一以單一幣別加總）

## Test plan

- [x] 新增台股資產 → `priceCurrency` 應為 TWD；成本價欄顯示 `TWD` 標籤
- [x] 新增加密貨幣資產 → `priceCurrency` 應為 USD；成本價欄顯示 `USD` 標籤
- [x] 更新資產價格 → 確認 `priceCurrency` 隨 API 來源寫入（CRYPTO → USD，STOCK → TWD）
- [x] 資產管理頁混合持有台股 + 加密貨幣 → 顯示兩組分開的統計卡片，各有正確幣別 suffix
- [x] 純台股帳戶 → 只顯示 TWD 卡片；純加密貨幣帳戶 → 只顯示 USD 卡片
- [x] 轉帳頁建立轉帳 → 選擇加密貨幣資產後，單價欄顯示 `USD`；台股顯示 `TWD`
- [x] `./mvnw test` 全部通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)