### PR TITLE
feat(exchange-rate): add USD/TWD rate conversion for portfolio total

### DIFF
--- a/backend/src/main/java/com/pocketfolio/backend/controller/ExchangeRateController.java
+++ b/backend/src/main/java/com/pocketfolio/backend/controller/ExchangeRateController.java
@@ -1,0 +1,28 @@
+package com.pocketfolio.backend.controller;
+
+import com.pocketfolio.backend.dto.PriceData;
+import com.pocketfolio.backend.service.ExchangeRateService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/exchange-rate")
+@RequiredArgsConstructor
+@Tag(name = "匯率", description = "外幣匯率查詢")
+@SecurityRequirement(name = "bearerAuth")
+public class ExchangeRateController {
+
+    private final ExchangeRateService exchangeRateService;
+
+    @GetMapping("/usd-twd")
+    @Operation(summary = "查詢 USD/TWD 匯率", description = "從 Yahoo Finance 取得即時匯率，快取 5 分鐘")
+    public ResponseEntity<PriceData> getUsdToTwd() {
+        return ResponseEntity.ok(exchangeRateService.getUsdToTwd());
+    }
+}

--- a/backend/src/main/java/com/pocketfolio/backend/dto/PriceData.java
+++ b/backend/src/main/java/com/pocketfolio/backend/dto/PriceData.java
@@ -18,6 +18,10 @@ import java.time.LocalDateTime;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PriceData implements Serializable {
 
+    // 明確指定 serialVersionUID，避免加欄位時 Redis 反序列化失敗
+    @SuppressWarnings("java:S5961")
+    private static final long serialVersionUID = 2L;
+
     private String symbol;           // 代號
     private BigDecimal price;        // 價格
     private String currency;         // 幣別：USD（加密貨幣）/ TWD（台股）

--- a/backend/src/main/java/com/pocketfolio/backend/service/ExchangeRateService.java
+++ b/backend/src/main/java/com/pocketfolio/backend/service/ExchangeRateService.java
@@ -1,0 +1,39 @@
+package com.pocketfolio.backend.service;
+
+import com.pocketfolio.backend.dto.PriceData;
+import com.pocketfolio.backend.service.external.YahooFinanceService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ExchangeRateService {
+
+    private static final String USD_TWD_SYMBOL = "USDTWD=X";
+    private static final BigDecimal FALLBACK_RATE = new BigDecimal("32.0");
+
+    private final YahooFinanceService yahooFinanceService;
+
+    /**
+     * 取得 USD → TWD 匯率（結果由 YahooFinanceService 的 @Cacheable 快取 5 分鐘）
+     * 若 Yahoo Finance 無法取得，回傳保守預設值並記錄警告。
+     */
+    public PriceData getUsdToTwd() {
+        PriceData data = yahooFinanceService.getPrice(USD_TWD_SYMBOL);
+        if (data == null || data.getPrice() == null) {
+            log.warn("無法取得 USD/TWD 匯率，使用預設值 {}", FALLBACK_RATE);
+            return PriceData.builder()
+                    .symbol(USD_TWD_SYMBOL)
+                    .price(FALLBACK_RATE)
+                    .currency("TWD")
+                    .source("FALLBACK")
+                    .build();
+        }
+        data.setCurrency("TWD");
+        return data;
+    }
+}

--- a/docs/DEV_INCIDENTS.md
+++ b/docs/DEV_INCIDENTS.md
@@ -46,6 +46,7 @@
 | day23 | Bug | `sockjs-client` 在 Vite 環境報錯（global 未定義） | SockJS 是 CommonJS 套件，用了 Node.js 的 `global` 變數，瀏覽器沒有 | 在 `vite.config.ts` 加 `define: { global: 'globalThis' }` polyfill |
 | day23 | Bug | WebSocket 用 `ws://` URL 連線失敗 | SockJS 自己處理協議升級，不接受 `ws://`，要傳 `http://` | 改用 `http://` URL，讓 SockJS 自行升級為 WebSocket 連線 |
 | day23 | 架構設計 | WebSocket 跨元件通訊：Zustand timestamp 方案 | `MainLayout` 收到 WS 推播後，如何通知深層子元件（AssetList）刷新 | Zustand store 存 `lastPriceUpdateAt` 時間戳，`AssetList` 用 `useEffect` 監聽，timestamp 改變就 reload |
+| day20~21 | Bug | 前端刪除有關聯資料的類別時沒有友善提示 | 後端拋出 Foreign Key Constraint 例外，前端直接顯示原始錯誤 | `catch` 區塊捕捉後端例外，顯示中文友善提示 |
 | day24 | Bug | `Input` import 被誤刪導致頁面 crash | 把 symbol 欄位改成 AutoComplete 時順手刪掉 `Input` import，但備註欄仍用 `Input.TextArea` | 把 `Input` 加回 import 清單；教訓：刪 import 前搜尋整個檔案 |
 | day24 | Bug | 單元測試驗證順序與業務邏輯不符 | `assetCostPrice == null` 的驗證放在 `findById()` 之前，「資產不存在」測試反而被 costPrice 驗證攔截，拋錯訊息不對 | 把 costPrice 驗證移入各自的業務分支（加倉 / 新增），確保驗證順序符合邏輯流程 |
 | day24 | Bug | Production 出現 duplicate key（JPA flush 順序問題） | `deleteByAssetType()` 是 JPQL，Hibernate 可能把 DELETE 和後續 INSERT 排進同一批次，導致 unique constraint 衝突 | 在 delete 後顯式呼叫 `flush()`，強制 DELETE 先送達資料庫再執行 INSERT |
@@ -55,6 +56,31 @@
 | day25 | Bug | 加 `currency` 欄位後 Redis 反序列化失敗 | `PriceData` 實作 `Serializable`，class 結構改變導致 Java 重新算 `serialVersionUID`，舊快取物件無法反序列化，API 全壞 | 立即：`redis-cli FLUSHALL` 清快取。根本：加明確的 `serialVersionUID = 2L`，之後加欄位不會改變 UID |
 | day25 | 架構設計 | 匯率 fallback 防禦設計 | Yahoo Finance 若無法取得 `USDTWD=X`，投資組合總計 Banner 不能直接壞掉 | fallback 回傳預設值 32.0，並在 UI 上標示「預設值」，降級而非崩潰 |
 | day25 | 工具 | `docker-compose down -v` 清掉本地資料庫 | `-v` 參數會一起刪 Docker volume，PostgreSQL 資料完全清空；之後啟動 Hibernate 把空 tables 重建 | 本地開發不加 `-v`；Production 用 Cloud SQL，不受 Docker volume 影響 |
+
+---
+
+## 從 git 歷史補充的事件
+
+| Commit | 分類 | 標題 | 詳情 | 解決辦法 |
+|---|---|---|---|---|
+| `a5fcdc1` | Bug | Spring Boot 啟動失敗：`PriceAlertService` 循環依賴 | `PriceAlertService` 依賴 `PriceService`，`PriceService` 間接依賴回來，Spring 無法建立 Bean | 把即時價格補充邏輯下放到 Controller 層（呼叫端），打破 Service 層的循環 |
+| `37e92e9` | 架構設計 | 轉帳記錄被統計到收支，導致帳戶餘額雙重計算 | `TRANSFER_IN` 被算成收入、`TRANSFER_OUT` 算成支出，加總後錢憑空多出來 | 統計查詢和餘額計算一律排除 `TRANSFER_*` 類型；`transferGroupId` 讓兩筆記錄配對，刪一筆自動刪另一筆 |
+| `78aa860` | Bug | CoinGecko `/coins/list` 回應超過 WebClient 緩衝區上限，靜默失敗 | WebClient 預設 256KB，CoinGecko 幣種清單約 1MB，超過後直接拋例外但被吞掉，同步看起來成功實際上沒資料 | 用 `ExchangeStrategies` 設定 WebClient buffer 為 5MB |
+| `b341277` | Bug | 啟動時只判斷「知名資產 DB 是否為空」，導致 CRYPTO 沒被同步 | `known_assets` 有台股資料就判定「不是空的」，跳過全部同步；CRYPTO 欄位永遠是空的 | 改為對每個 `assetType`（STOCK_TW / STOCK_TWO / CRYPTO）個別判斷是否為空再決定是否同步 |
+| `2f372d2` | Bug | CoinGecko 部分幣種 symbol 超過欄位長度，`INSERT` 失敗 | 欄位定義 `VARCHAR(20)`，部分垃圾幣 symbol 長達 38 字元，批次寫入整批失敗 | 調整欄位長度：`display_code` 20→100、`symbol` 30→100、`name` 100→200 |
+| `5bd6f5e` | 架構設計 | 把 CoinGecko 來源從 `/coins/list` 換成 `/coins/markets` | `/coins/list` 有 15,000+ 幣種含大量下架垃圾幣，搜尋結果品質很差 | 改用 `/coins/markets?vs_currency=usd&order=market_cap_desc&per_page=200`，只同步市值前 200 名，搜尋結果順序帶 `market_cap_rank` |
+| `5bd6f5e` | Bug | 舊資產 CoinGecko ID 存大寫，API 查詢 404 | CoinGecko API 要求 id 是小寫（如 `bitcoin`），舊資料存成 `BITCOIN` 導致查價格回 404 | `CoinGeckoService.getPrice()` 統一對輸入做 `toLowerCase()`，相容舊資料 |
+| `5bd6f5e` | Bug | `LocalDateTime` 預設序列化為陣列，前端顯示 `Invalid Date` | Jackson 預設把 `LocalDateTime` 序列化成 `[2026,3,1,12,0,0]` 數字陣列，`new Date(陣列)` 解析失敗 | 在 `application.yaml` 加 `write-dates-as-timestamps: false`，強制輸出 ISO 8601 字串 |
+| `7f50d7d` | Bug | `@Retryable` / `@Transactional` 在 Service 內部自呼叫完全失效 | `KnownAssetSyncService.syncAll()` 用 `this::syncTwse` 呼叫自己，繞過 Spring AOP 代理，retry 和 transaction 都沒生效 | 移除 `syncAll()`，改由 `KnownAssetSyncScheduler` 直接透過注入的 proxy 呼叫各 sync 方法 |
+| `06327ca` | Bug | `Thread.sleep` 放在 `getPrice()` 內，使用者手動刷新也被卡住 | 限速 sleep 寫在 `CoinGeckoService.getPrice()` 裡，快取命中時也會休眠，使用者觸發的即時查詢同樣被阻塞 | 把 sleep 移到 `PriceService.updateAllAssetPrices()` 的批次迴圈裡，只在實際呼叫外部 API（非快取命中）後才休眠 |
+| `5c7e178` | Bug | CI 啟動時 `@EventListener` 呼叫外部 API 導致測試失敗 | `@SpringBootTest` 啟動完整 Spring context，`ApplicationReadyEvent` 觸發 `KnownAssetSyncScheduler` 呼叫 TWSE / CoinGecko，CI 沒有外部網路 | 在測試設定中用 `@MockitoBean` 替換 `KnownAssetSyncScheduler`，阻止外部 API 呼叫 |
+| `4e35918` | 部署 | CI 後端測試無法啟動 Spring context（沒有 PostgreSQL / Redis） | GitHub Actions 的 runner 沒有資料庫，`@SpringBootTest` 連線失敗，整個 test job 掛掉 | 在 workflow yml 加 `services:` 區塊，起 `postgres:16` 和 `redis:7` 容器 |
+| `02d1782` | 部署 | ESLint v8→v9 升級導致 CI lint 失敗 | ESLint v9 改用 flat config，`--ext` flag 已移除；`eslint-plugin-react-hooks` 也需要對應的 v9 版 | 升級所有相關 eslint 套件、更新 `eslint.config.js` 格式、修掉所有 lint 錯誤（`any` 型別等） |
+| `8b671ab` | 部署 | Cloud Run 滾動更新期間資料庫連線數超上限，FATAL 錯誤 | `db-f1-micro` `max_connections=25`，滾動更新時舊版和新版同時存在，預設 `HikariCP pool-size=10` × 2 個實例 = 20，加上其他連線就超過 25 | 把 `maximum-pool-size` 降為 5，`minimum-idle` 降為 2，讓多版本共存時也不超限 |
+| `b5f75df` | 部署 | CI 拉 Docker 基底映像時觸發 Docker Hub 流量限制 | GitHub Actions 使用的 IP 屬於大量用戶共用，Docker Hub 對匿名用戶有拉取次數限制（每 6 小時 100 次） | 把 `Dockerfile` 的基底映像改成 `mirror.gcr.io/library/eclipse-temurin`，從 Google 的 GCR 快取拉取，不限速 |
+| `a775357` | 部署 | `--set-env-vars` 多行環境變數注入失敗 | `gcloud run deploy --set-env-vars` 在 shell 多行字串時帶入空白字元，導致 env var 值解析錯誤 | 改用 Python 讀取 yaml 再寫成 `KEY=VALUE` 格式的檔案，用 `--env-vars-file` 注入 |
+| `a775357` | 部署 | 第一次部署到 Cloud SQL 失敗（schema 不存在） | `ddl-auto: validate` 要求 schema 已存在才能啟動，但 Cloud SQL 是全新的空資料庫 | 第一次部署改用 `ddl-auto: update` 讓 Hibernate 自動建 schema；之後保持 `update` 避免風險 |
+| `dcacf23` / `ac2a754` | 部署 | Production CORS 擋掉 Firebase Hosting 的 API 請求與 WebSocket 握手 | CORS 設定只允許 `localhost`，部署後 Firebase 的 domain 被擋；WebSocket 的 CORS 和 Spring Security 的 CORS 是**分開**設定的，漏掉一個就 403 | 在 `SecurityConfig` 的 CORS 設定和 `WebSocketConfig` 的 `setAllowedOrigins` 都加上 Firebase Hosting domain |
 
 ---
 

--- a/docs/DEV_INCIDENTS.md
+++ b/docs/DEV_INCIDENTS.md
@@ -1,0 +1,76 @@
+# PocketFolio 開發事件紀錄
+
+> 記錄開發過程中遇到的問題、決策與解法。每一筆都是真實踩過的坑，是這個專案最有價值的部分。
+>
+> 更新時間：2026-05-09
+
+---
+
+## 格式說明
+
+| 欄位 | 說明 |
+|---|---|
+| 日期 | 對應 dev_log 的 day 編號 |
+| 分類 | Bug / 架構設計 / 效能 / 資安 / 部署 / 工具 |
+| 標題 | 一句話說明問題或決策 |
+| 詳情 | 問題根因或設計背景 |
+| 解決辦法 | 具體怎麼解的 |
+
+---
+
+## 事件總表
+
+| 日期 | 分類 | 標題 | 詳情 | 解決辦法 |
+|---|---|---|---|---|
+| day3 | 架構設計 | 不直接回傳 Entity，改用 DTO | Entity 若有敏感欄位（如 userId）會直接暴露給前端 | 建立獨立的 `*Response` DTO，Service 層做轉換 |
+| day3 | 架構設計 | 統一錯誤格式（GlobalExceptionHandler） | 各 Controller 的錯誤格式不一，前端難以統一處理 | 建立 `GlobalExceptionHandler`，所有錯誤統一回傳標準 JSON |
+| day4 | Bug | `ArgumentCaptor` 才能驗證存入資料庫的值 | 只驗證回傳值抓不到「Service 把數字改掉再存」的 bug（如把 1000 改成 0） | 用 `ArgumentCaptor` 在 `save()` 被呼叫時攔截參數，直接比對存入值 |
+| day5 | Bug | IDE 無法啟動後端（Java Runtime 路徑問題） | 直接在終端機下 `mvn` 指令找不到 Java Runtime | 改用 IntelliJ 點擊綠色三角形啟動，環境最穩定 |
+| day5 | Bug | REST Client 裡 UUID 解析失敗（中文字串未替換） | 測試腳本裡的「替換成實際UUID」沒有換成真實 UUID，Spring 無法解析 | 確認測試腳本的佔位符全部換成實際值 |
+| day7 | Bug | 複製貼上：`categoryRepository` 誤用在 Account 查詢 | 大量複製貼上導致 Repository 注入物件用錯 | Code Review 時注意 Repository 的使用對象是否與業務對象一致 |
+| day7 | 架構設計 | 瀑布流邏輯：條件判斷要從嚴格到寬鬆 | 查詢條件若順序寫反，寬鬆條件會提早攔截，嚴格條件永遠跑不到 | 判斷鏈從最嚴格（複合條件）寫到最寬鬆（單一條件） |
+| day8 | Bug | 帳戶餘額消失（動態計算未涵蓋所有交易類型） | 統計餘額的 JPQL 只計算 INCOME / EXPENSE，沒有計算 TRANSFER | 補上 TRANSFER_IN / TRANSFER_OUT 的金額計算邏輯 |
+| day11 | Bug | Redis 啟動衝突（本機 brew services 佔用 6379 port） | Mac 上 Homebrew 安裝的 Redis service 已佔用 6379，Docker 無法綁定 | `brew services stop redis`，讓 Docker Redis 接管 |
+| day11 | 架構設計 | Redis 預設序列化產生亂碼 | 預設的位元組序列化在 TablePlus / redis-cli 中無法閱讀 | 改用 `StringRedisSerializer`（key）+ `GenericJackson2JsonRedisSerializer`（value） |
+| day12 | Bug | `@CacheEvict` 在 Service 內部呼叫自己失效 | Spring AOP 代理只攔截從外部進來的呼叫，Service 自己呼叫自己會繞過代理 | 把快取清除邏輯移出，或改用 SpEL 動態 key 直接在正確的地方清 |
+| day12 | 效能 | `findAll()` 會把整張表載入記憶體 | 資產數量大時直接 OOM，系統崩潰 | 改用 `PageRequest` 分頁查詢，每次只取 100 筆 |
+| day12 | Bug | `ObjectMapper` Bean 污染全域 JSON 解析 | 為 Redis 開啟 DefaultTyping 的 ObjectMapper 被 Spring MVC 拿去解析 API 請求，前端登入時因缺少 `@class` 屬性而 500 | 改為私有方法 `redisObjectMapper()`，不標記 `@Bean`，只傳給 Redis Serializer 使用 |
+| day12 | Bug | DTO 的 `isExpired()` 被 Jackson 誤認為欄位 | Jackson 把 `is` 開頭的方法當作 boolean getter，序列化成 `expired` 欄位存入 Redis，反序列化時 `UnrecognizedPropertyException` | 加 `@JsonIgnore`；類別加 `@JsonIgnoreProperties(ignoreUnknown = true)` |
+| day12 | 架構設計 | 快取命中時仍然 `Thread.sleep`（限速邏輯放錯位置） | sleep 和更新時間戳寫在呼叫端，即使從快取拿到資料也會休眠，回傳時間也是錯的 | 把 `@Cacheable`、時間戳、sleep 全部下放到 `CoinGeckoService` / `YahooFinanceService`，快取命中直接 return，不休眠 |
+| day13 | Bug | WebSocket 握手被 Spring Security 攔截（401/403） | JWT 驗證 filter 把 `/ws` 握手請求當成一般 API 請求處理 | 在 `SecurityConfig` 把握手端點 `/ws/**` 加入 `permitAll()`，STOMP 層再做身份驗證 |
+| day14 | Bug | Swagger UI 路徑 403 | Spring Security 預設封鎖所有路徑，Swagger 的靜態資源和 API docs 路徑未放行 | 把 `/swagger-ui/**`、`/v3/api-docs/**` 加入 `permitAll()` 白名單 |
+| day14 | Bug | Swagger 啟動 HTTP 500 / `NoSuchMethodError` | `springdoc-openapi` 版本與 Spring Boot 3.4 不相容 | 升級到相容版本（2.8.4 以上） |
+| day16 | Bug | 循環依賴（Circular Dependency）導致啟動失敗 | Service A 注入 Service B，Service B 又注入 Service A | 重新梳理依賴方向，抽出共用邏輯到第三個 Service，打破循環 |
+| day22 | 架構設計 | 複合索引欄位順序：user_id 放前、date 放後 | 所有查詢都同時帶 user_id 過濾，單獨加 date 索引沒有意義 | `@Index(columnList = "user_id, date")`，先縮小用戶範圍再走日期排序 |
+| day22 | Bug | JWT 過期後畫面無反應（沒有導向 /login） | Token 過期後 API 回 401，但前端沒有攔截處理 | Axios response interceptor 攔截 401，自動清除 token 並 redirect 到 `/login` |
+| day23 | Bug | `sockjs-client` 在 Vite 環境報錯（global 未定義） | SockJS 是 CommonJS 套件，用了 Node.js 的 `global` 變數，瀏覽器沒有 | 在 `vite.config.ts` 加 `define: { global: 'globalThis' }` polyfill |
+| day23 | Bug | WebSocket 用 `ws://` URL 連線失敗 | SockJS 自己處理協議升級，不接受 `ws://`，要傳 `http://` | 改用 `http://` URL，讓 SockJS 自行升級為 WebSocket 連線 |
+| day23 | 架構設計 | WebSocket 跨元件通訊：Zustand timestamp 方案 | `MainLayout` 收到 WS 推播後，如何通知深層子元件（AssetList）刷新 | Zustand store 存 `lastPriceUpdateAt` 時間戳，`AssetList` 用 `useEffect` 監聽，timestamp 改變就 reload |
+| day24 | Bug | `Input` import 被誤刪導致頁面 crash | 把 symbol 欄位改成 AutoComplete 時順手刪掉 `Input` import，但備註欄仍用 `Input.TextArea` | 把 `Input` 加回 import 清單；教訓：刪 import 前搜尋整個檔案 |
+| day24 | Bug | 單元測試驗證順序與業務邏輯不符 | `assetCostPrice == null` 的驗證放在 `findById()` 之前，「資產不存在」測試反而被 costPrice 驗證攔截，拋錯訊息不對 | 把 costPrice 驗證移入各自的業務分支（加倉 / 新增），確保驗證順序符合邏輯流程 |
+| day24 | Bug | Production 出現 duplicate key（JPA flush 順序問題） | `deleteByAssetType()` 是 JPQL，Hibernate 可能把 DELETE 和後續 INSERT 排進同一批次，導致 unique constraint 衝突 | 在 delete 後顯式呼叫 `flush()`，強制 DELETE 先送達資料庫再執行 INSERT |
+| day24 | 架構設計 | AutoComplete 保護機制（確認 Tag） | 選取資產後使用者仍可繼續打字，form 裡的 symbol 和畫面顯示不一致，有誤填資產的風險 | 選取後把 AutoComplete 替換成確認 Tag（`CheckCircleOutlined`），點「重新選擇」才回到輸入框 |
+| day24 | 架構設計 | 轉帳金額自動計算並鎖定 | 讓使用者同時填「總金額」和「成本價」，兩個欄位本質相同，容易搞混 | 改為填「數量」+「單價」，金額 = 數量 × 單價自動計算，欄位設為 `disabled` |
+| day25 | Bug | 加密貨幣（USD）與台股（TWD）市值混算 | CoinGecko 回 USD、Yahoo Finance 回 TWD，存入同一個 `currentPrice` 欄位，前端加總後標示 TWD，數字完全錯誤 | `Asset` entity 加 `priceCurrency` 欄位；前端統計卡片按幣別分組顯示，不跨幣別加總 |
+| day25 | Bug | 加 `currency` 欄位後 Redis 反序列化失敗 | `PriceData` 實作 `Serializable`，class 結構改變導致 Java 重新算 `serialVersionUID`，舊快取物件無法反序列化，API 全壞 | 立即：`redis-cli FLUSHALL` 清快取。根本：加明確的 `serialVersionUID = 2L`，之後加欄位不會改變 UID |
+| day25 | 架構設計 | 匯率 fallback 防禦設計 | Yahoo Finance 若無法取得 `USDTWD=X`，投資組合總計 Banner 不能直接壞掉 | fallback 回傳預設值 32.0，並在 UI 上標示「預設值」，降級而非崩潰 |
+| day25 | 工具 | `docker-compose down -v` 清掉本地資料庫 | `-v` 參數會一起刪 Docker volume，PostgreSQL 資料完全清空；之後啟動 Hibernate 把空 tables 重建 | 本地開發不加 `-v`；Production 用 Cloud SQL，不受 Docker volume 影響 |
+
+---
+
+## 常用 Debug 指令備查
+
+```bash
+# 清 Redis 快取（序列化不相容時的急救措施）
+docker exec -it pocketfolio-redis redis-cli FLUSHALL
+
+# 查資料庫各 table 筆數
+docker exec -it pocketfolio-db psql -U admin -d pocketfolio -c \
+  "SELECT 'users' as t, COUNT(*) FROM users
+   UNION ALL SELECT 'accounts', COUNT(*) FROM accounts
+   UNION ALL SELECT 'transactions', COUNT(*) FROM transactions
+   UNION ALL SELECT 'assets', COUNT(*) FROM assets;"
+
+# 列出所有 tables
+docker exec -it pocketfolio-db psql -U admin -d pocketfolio -c "\dt"
+```

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -54,7 +54,7 @@
 - [x] 前端 AssetList：統計卡片按幣別分組（台股 TWD / 加密貨幣 USD），不混算
 - [x] 前端 AssetList 表格：成本價、當前價格、市值欄動態顯示幣別 label
 - [x] 前端表單（AssetList、TransactionList）：成本/單價欄位顯示幣別提示（USD/TWD）
-- [ ] （長期）引入匯率換算，統一以 TWD 加總顯示投資組合總值（`feature/exchange-rate`）
+- [x] （長期）引入匯率換算，統一以 TWD 加總顯示投資組合總值（`feature/exchange-rate`）
 
 ### 3. 手動資產輸入（新分支：`feature/manual-asset-entry`）
 **目標：** 讓使用者可以輸入不在已知清單的資產（美股、非前 200 幣等）。

--- a/docs/dev_logs/day24.md
+++ b/docs/dev_logs/day24.md
@@ -1,0 +1,137 @@
+# day 24
+
+## 轉帳連結資產（feature/transfer-link-asset）
+
+### 任務說明
+
+在交易頁建立轉帳時，若目標帳戶是投資帳戶，使用者可以：
+- **加倉**：選擇既有資產，追加數量並重新計算加權平均成本
+- **新增資產**：直接從轉帳動作同時建立一筆資產記錄
+
+這樣「轉帳資金到投資帳戶」和「記錄買進資產」可以一次完成，不用分兩步操作。
+
+---
+
+### 後端設計
+
+#### `TransactionRequest` 加入 7 個選填欄位
+
+```java
+private UUID assetId;         // 加倉：指定既有資產 ID
+private AssetType assetType;
+private String assetSymbol;
+private String assetName;
+private BigDecimal assetQuantity;
+private BigDecimal assetCostPrice;  // 單價，amount = qty × costPrice（前端計算）
+private String assetNote;
+```
+
+#### `TransactionService.linkAssetIfNeeded()` 邏輯
+
+1. 目標帳戶不是 INVESTMENT → 直接 return（不影響現有流程）
+2. 沒有帶資產欄位 → 直接 return
+3. **加倉路徑**：找到資產 → 驗證所有權與帳戶歸屬 → 更新數量 + 加權平均成本
+4. **新增路徑**：驗證 symbol 唯一 → 建立新的 Asset entity
+
+加權平均成本公式：
+```
+新成本價 = (舊數量 × 舊成本價 + 加倉數量 × 買入單價) / (舊數量 + 加倉數量)
+```
+
+---
+
+### 前端設計
+
+#### 核心 UX 決策：金額欄位自動計算並鎖定
+
+一開始設計讓使用者填「總金額」和「成本價」，後來發現兩個欄位其實是同一件事的不同呈現，容易混淆。
+
+最終決定：使用者填「**數量**」和「**單價**」，金額 = 數量 × 單價自動計算，金額欄位 `disabled`。
+
+#### AutoComplete 保護機制
+
+問題：AutoComplete 是文字輸入框，使用者選完後還可以繼續打字，導致 `form` 裡的 `symbol` 和搜尋框顯示的文字不一致，有記錯資產的風險。
+
+解法：選取後把 AutoComplete 換成一個確認 Tag，只有點「重新選擇」才能回到輸入框。
+
+```tsx
+{selectedAssetDisplay ? (
+  <Tag icon={<CheckCircleOutlined />} color="success">
+    {selectedAssetDisplay}
+  </Tag>
+  <Button type="link" onClick={clearSelectedAsset}>重新選擇</Button>
+) : (
+  <AutoComplete ... />
+)}
+```
+
+同樣的保護機制也套用到資產管理頁（AssetList）。
+
+#### 選取後顯示當前市價
+
+選完資產後呼叫 `/api/prices/{symbol}?type=CRYPTO` 取得即時價格，顯示在確認 Tag 旁邊，讓使用者填單價時有參考依據。
+
+---
+
+### 遇到的問題
+
+#### 問題 1：Input 未定義的 crash
+
+把 symbol 欄位改成 AutoComplete 時，刪掉了 `Input` 的 import，但 `Input.TextArea`（備註欄）還在用它。頁面直接 crash。
+
+解法：把 `Input` 加回 import 清單。教訓：刪 import 前先確認整個檔案的用法。
+
+#### 問題 2：單元測試驗證順序錯誤
+
+`linkAssetIfNeeded()` 裡把 `assetCostPrice == null` 的驗證放在 `assetRepository.findById()` 之前。結果「資產不存在」和「資產屬於別人」這兩個測試案例在驗證 costPrice 那一關就先失敗了，拋出錯誤訊息不對。
+
+解法：把 costPrice 的驗證移到各自的 if 分支內部（加倉分支 / 新增分支），確保驗證順序與業務邏輯流程一致。
+
+#### 問題 3：Production 出現 duplicate key 錯誤
+
+```
+ERROR: duplicate key value violates unique constraint "known_assets_symbol_key"
+```
+
+`KnownAssetSyncService` 在 `deleteByAssetType()` 之後直接 `saveAll()`，但 JPA 的 `deleteByAssetType()` 是 JPQL，flush 時機由 Hibernate 決定——Hibernate 可能把 DELETE 和 INSERT 排在同一批次，導致新舊資料的 unique constraint 衝突。
+
+解法：在 delete 後加 `flush()`，強制 DELETE 先抵達資料庫，再執行 INSERT。
+
+```java
+knownAssetRepository.deleteByAssetType("CRYPTO");
+knownAssetRepository.flush();  // 確保 DELETE 先送達
+knownAssetRepository.saveAll(toSave);
+```
+
+這個 bug 在開這個 feature 的時候在 production 爆出來，開了獨立的 hotfix branch（`fix/known-asset-sync-flush`，PR #13），stash 手邊的工作 → 切去修 → PR merge → 回來繼續。
+
+---
+
+### 單元測試（TransactionServiceTest，8 個新測試）
+
+| 測試案例 | 驗證重點 |
+|---|---|
+| `linkAsset_nonInvestmentAccount_noAssetOperation` | 非投資帳戶不觸發資產邏輯 |
+| `linkAsset_withAssetId_updatesQuantityAndWeightedCost` | 加倉加權平均成本正確（10@800 + 10@900 = 850） |
+| `linkAsset_withNewSymbol_createsAsset` | 新資產 symbol 自動轉大寫 |
+| `linkAsset_zeroQuantity_throws` | 數量為 0 拋例外 |
+| `linkAsset_assetIdNotFound_throws` | 找不到資產 ID 拋例外 |
+| `linkAsset_assetOwnedByOther_throws` | 資產屬於別人拋例外 |
+| `linkAsset_assetInDifferentAccount_throws` | 資產在不同帳戶拋例外 |
+| `linkAsset_duplicateSymbol_throws` | 同帳戶重複 symbol 拋例外 |
+
+---
+
+### 面試素材 🗣️
+
+「你怎麼確保轉帳和資產更新的一致性？」
+
+「兩個操作都在同一個 `@Transactional` 方法裡。Spring 的事務管理確保轉帳記錄和資產更新要麼全部成功、要麼全部 rollback，不會出現轉帳成功但資產沒更新的中間狀態。」
+
+「加權平均成本是什麼，你為什麼用這個？」
+
+「這是投資裡計算持倉成本的標準方式。例如第一次買 10 股 @800，第二次加倉 10 股 @900，加權平均成本就是 850，而不是直接用最新的 900。這樣損益計算才能反映真實的平均持倉成本。公式：(舊數量 × 舊成本 + 新數量 × 新單價) / 總數量。」
+
+「你遇過 JPA 的 flush 問題嗎？」
+
+「有。在同步資產清單的 Service 裡，我做了 deleteAll 再 saveAll，Hibernate 有時會把兩者放在同一個 flush batch，DELETE 還沒到資料庫，INSERT 就先進去，觸發 unique constraint 衝突。解法是在 delete 後顯式呼叫 `flush()`，強制 Hibernate 先送 DELETE，這在 production 確實出現過，所以印象很深。」

--- a/docs/dev_logs/day25.md
+++ b/docs/dev_logs/day25.md
@@ -1,0 +1,163 @@
+# day 25
+
+## 加密貨幣幣別不一致（feature/asset-price-currency + feature/exchange-rate）
+
+### 問題發現
+
+資產管理頁的「總市值」數字是錯的。
+
+根本原因：
+- Yahoo Finance 回傳台股價格是 **TWD**
+- CoinGecko 回傳加密貨幣價格是 **USD**
+- 兩者都存在 `asset.currentPrice`，前端直接加總並標示 `TWD`
+
+例如持有台積電市值 300,000 TWD + BTC 市值 100,000 USD，前端顯示「總市值 400,000 TWD」——這個數字毫無意義。
+
+---
+
+### 解法一：追蹤幣別（feature/asset-price-currency）
+
+#### 後端
+
+在 `Asset` entity 加 `priceCurrency` 欄位（`VARCHAR(3)`）：
+
+```java
+@Column(length = 3)
+private String priceCurrency;  // "TWD" 或 "USD"
+```
+
+在 `PriceData` DTO 也加 `currency` 欄位，讓外部 Service 主動標記：
+
+```java
+// CoinGeckoService
+return PriceData.builder().price(price).currency("USD").build();
+
+// YahooFinanceService
+return PriceData.builder().price(price).currency("TWD").build();
+```
+
+`PriceService.updateAssetPrice()` 更新價格時一併寫入 `priceCurrency`。
+`AssetService.createAsset()` 建立資產時依 type 初始化（CRYPTO → USD，其餘 → TWD）。
+
+#### 前端
+
+- 表格的成本價、當前價格、市值欄各自顯示幣別 label
+- 統計卡片按幣別分兩組顯示（台股 TWD / 加密貨幣 USD），不再混算
+
+---
+
+### 解法二：匯率換算顯示總計（feature/exchange-rate）
+
+分開顯示解決了「數字不混算」的問題，但使用者還是想知道「我的投資組合總共值多少」。
+
+#### 設計思路
+
+不引入新的外部 API——Yahoo Finance 本身就支援匯率代號 `USDTWD=X`，我們已有 `YahooFinanceService`，直接重用。
+
+#### 後端
+
+新建 `ExchangeRateService`：
+
+```java
+public PriceData getUsdToTwd() {
+    PriceData data = yahooFinanceService.getPrice("USDTWD=X");
+    // 若無法取得，回傳預設值 32.0 並標記 source = FALLBACK
+    if (data == null) return fallback();
+    data.setCurrency("TWD");
+    return data;
+}
+```
+
+快取直接沿用 `YahooFinanceService` 的 `@Cacheable`（Redis，5 分鐘 TTL），不需要額外設定。
+
+新增 `GET /api/exchange-rate/usd-twd` endpoint。
+
+#### 前端
+
+`AssetList` 頁面載入時同步拉匯率，當帳戶同時有台股和加密貨幣時，在統計卡片下方顯示「投資組合總市值（TWD）」Banner：
+
+```
+投資組合總市值（TWD）　1,234,567 TWD
+匯率：1 USD = 32.54 TWD
+```
+
+計算公式：
+```
+totalTwd = twdMarketValue + usdMarketValue × rate
+```
+
+---
+
+### 遇到的問題
+
+#### 問題 1：Redis 反序列化失敗 → 使用者登入後出錯
+
+替 `PriceData` 加了 `currency` 欄位後，Redis 裡還快取著舊的 `PriceData` 序列化物件（沒有 `currency` 欄位）。Java 的 `Serializable` 機制在 class 結構改變時會算出不同的 `serialVersionUID`，導致反序列化舊快取時拋出 `InvalidClassException`，整個 API 層壞掉。
+
+**診斷過程**：使用者登入後出錯，直覺以為是新功能的 bug，但其實是快取問題。
+
+**立即修復**：
+```bash
+docker exec -it pocketfolio-redis redis-cli FLUSHALL
+```
+
+**根本修復**：在 `PriceData` 加上明確的 `serialVersionUID`：
+```java
+private static final long serialVersionUID = 2L;
+```
+
+有了明確的版本號，之後再加欄位，Java 不會重新算 UID，舊快取讀到新欄位時直接用 `null` 填入，不會爆炸。
+
+**教訓**：任何實作 `Serializable` 且被放進快取的 class，改欄位時都必須：
+1. 清一次現有快取（立即解決）
+2. 設定明確的 `serialVersionUID`（防止下次再發生）
+
+#### 問題 2：本地資料庫資料被清空
+
+清 Redis 之後，使用者發現資料庫也空了。
+
+**診斷**：
+```bash
+docker exec -it pocketfolio-db psql -U admin -d pocketfolio -c \
+  "SELECT 'users', COUNT(*) FROM users UNION ALL SELECT 'assets', COUNT(*) FROM assets;"
+```
+結果全部 0 筆，但 tables 結構存在。
+
+**根本原因**：這跟程式改動無關。`ddl-auto: update` 只會加欄位，不會刪資料。最可能的原因是先前執行過 `docker-compose down -v`，`-v` 參數會一起刪掉 Docker volume（PostgreSQL 的資料就存在 volume 裡），之後 `docker-compose up` 時 Hibernate 把空白 tables 重建出來。
+
+**處理方式**：本地資料重新建立（重新註冊帳號）。Production 的 Cloud SQL 不受影響。
+
+**教訓**：本地開發做 `docker-compose down` 時，除非刻意要清資料，否則不要加 `-v`。
+
+---
+
+### 架構小結
+
+```
+CoinGeckoService  → PriceData { price: 95000, currency: "USD" }
+YahooFinanceService → PriceData { price: 1025, currency: "TWD" }
+                          ↓
+                   PriceService.updateAssetPrice()
+                   asset.currentPrice = 95000
+                   asset.priceCurrency = "USD"   ← 新增
+                          ↓
+                   AssetResponse { priceCurrency: "USD" }
+                          ↓ (frontend)
+                   分組顯示 + 匯率換算 Banner
+```
+
+---
+
+### 面試素材 🗣️
+
+「你的系統同時有台股和加密貨幣，幣別怎麼處理？」
+
+「這是我主動發現並修掉的一個 bug。原本 CoinGecko 回傳 USD 價格、Yahoo Finance 回傳 TWD 價格，兩者直接存在同一個欄位裡，前端加總後標示 TWD——數字是完全錯的。我在 Asset entity 加了 `priceCurrency` 欄位，每次外部 API 回傳價格時一併記錄幣別。前端則把台股和加密貨幣的統計分開顯示，再透過 Yahoo Finance 的匯率代號 `USDTWD=X` 取得即時匯率，換算出以 TWD 計的投資組合總市值。」
+
+「你加了新欄位之後有沒有遇到什麼問題？」
+
+「有，踩了 Java 序列化的坑。`PriceData` 這個 class 是存在 Redis 裡的快取物件，它實作了 `Serializable`。我加了 `currency` 欄位後，Java 因為 class 結構改變而重新算出不同的 `serialVersionUID`，導致舊的快取物件無法反序列化，API 全部壞掉。修法是先手動清快取，然後在 class 上加明確的 `serialVersionUID = 2L`，之後再加欄位就不會有這個問題了。」
+
+「匯率怎麼取得的，有沒有考慮過第三方 API 掛掉的情況？」
+
+「匯率用 Yahoo Finance 的 `USDTWD=X` 代號，因為我們已經有 Yahoo Finance 的 WebClient，不需要引入新的第三方服務。快取 5 分鐘，對匯率這種慢變動資料已經很夠。掛掉的部分有做 fallback：如果 API 回傳 null，就用預設值 32.0，並在 UI 上標示『預設值』讓使用者知道這不是即時數據。這是一個防禦性設計——降級，而不是直接壞掉。」

--- a/frontend/src/api/exchangeRate.api.ts
+++ b/frontend/src/api/exchangeRate.api.ts
@@ -1,0 +1,16 @@
+import axios from './axios';
+
+export interface ExchangeRateData {
+  symbol: string;
+  price: number;       // 匯率，例如 32.5 代表 1 USD = 32.5 TWD
+  currency: string;
+  updateTime: string;
+  source: string;
+}
+
+export const exchangeRateApi = {
+  getUsdToTwd: async (): Promise<ExchangeRateData> => {
+    const response = await axios.get<ExchangeRateData>('/exchange-rate/usd-twd');
+    return response.data;
+  },
+};

--- a/frontend/src/pages/assets/AssetList.tsx
+++ b/frontend/src/pages/assets/AssetList.tsx
@@ -34,6 +34,7 @@ import dayjs from 'dayjs';
 import { assetApi } from '@/api/asset.api';
 import { accountApi } from '@/api/account.api';
 import { priceApi } from '@/api/price.api';
+import { exchangeRateApi, type ExchangeRateData } from '@/api/exchangeRate.api';
 
 import { knownAssetApi, type KnownAssetResult, type KnownAssetType } from '@/api/knownAsset.api';
 import { useWebSocketStore } from '@/store/websocketStore';
@@ -53,6 +54,7 @@ const AssetList = () => {
   const [modalVisible, setModalVisible] = useState(false);
   const [editingAsset, setEditingAsset] = useState<Asset | null>(null);
   const [updating, setUpdating] = useState(false);
+  const [exchangeRate, setExchangeRate] = useState<ExchangeRateData | null>(null);
   const [form] = Form.useForm();
   const { lastPriceUpdateAt } = useWebSocketStore();
 
@@ -135,12 +137,14 @@ const AssetList = () => {
 
   const loadAccounts = async () => {
     try {
-      const [investmentAccounts, all] = await Promise.all([
+      const [investmentAccounts, all, rate] = await Promise.all([
         accountApi.getAccounts({ type: 'INVESTMENT' }),
         accountApi.getAccounts(),
+        exchangeRateApi.getUsdToTwd().catch(() => null),
       ]);
       setAccounts(investmentAccounts);
       setAllAccounts(all);
+      setExchangeRate(rate);
       if (investmentAccounts.length > 0) {
         setSelectedAccount(investmentAccounts[0].id);
       }
@@ -260,6 +264,12 @@ const AssetList = () => {
   const usdCost = usdAssets.reduce((sum, a) => sum + a.costPrice * a.quantity, 0);
   const usdProfitLoss = usdMarketValue - usdCost;
   const usdProfitLossPercent = usdCost > 0 ? (usdProfitLoss / usdCost) * 100 : 0;
+
+  // 換算後的投資組合總計（僅在有加密貨幣時才顯示）
+  const rate = exchangeRate?.price ?? null;
+  const portfolioTotalTwd = rate !== null && usdAssets.length > 0
+    ? twdMarketValue + usdMarketValue * rate
+    : null;
 
   // 表格欄位
   const columns: ColumnsType<Asset> = [
@@ -517,6 +527,28 @@ const AssetList = () => {
 
           {/* 只有台股或只有加密貨幣時補間距 */}
           {twdAssets.length === 0 && usdAssets.length === 0 && <div style={{ marginBottom: 16 }} />}
+
+          {/* 投資組合總計（跨幣別換算） */}
+          {portfolioTotalTwd !== null && (
+            <Card
+              size="small"
+              style={{ marginBottom: 16, background: '#f6ffed', borderColor: '#b7eb8f' }}
+            >
+              <Space split={<span style={{ color: '#d9d9d9' }}>|</span>}>
+                <span>
+                  <Text type="secondary">投資組合總市值（TWD）</Text>
+                  {'　'}
+                  <Text strong style={{ fontSize: 18, color: '#3f8600' }}>
+                    {portfolioTotalTwd.toLocaleString('zh-TW', { maximumFractionDigits: 0 })} TWD
+                  </Text>
+                </span>
+                <Text type="secondary" style={{ fontSize: 12 }}>
+                  匯率：1 USD = {rate?.toFixed(2)} TWD
+                  {exchangeRate?.source === 'FALLBACK' ? '（預設值）' : ''}
+                </Text>
+              </Space>
+            </Card>
+          )}
 
           {/* 表格 */}
           <Table


### PR DESCRIPTION
## Summary

- **後端** `ExchangeRateService`：透過現有 `YahooFinanceService` 呼叫 `USDTWD=X`，沿用 Redis 快取（5 分鐘 TTL）；若 Yahoo Finance 無法取得，回傳預設值 32.0 並標記 source = FALLBACK
- **後端** `GET /api/exchange-rate/usd-twd`：回傳 `{ price, currency, updateTime, source }`
- **前端** `AssetList`：頁面載入時同步拉匯率；當帳戶同時有台股和加密貨幣資產時，在統計卡片下方顯示「投資組合總市值（TWD）」綠色 Banner，並附上匯率來源與數值

## Test plan

- [x] 混合台股 + 加密貨幣的帳戶 → Banner 顯示，總值 = 台股市值 + 加密貨幣市值 × 匯率
- [x] 純台股帳戶 → 不顯示 Banner
- [x] Yahoo Finance 無法取得匯率時 → Banner 仍顯示但標示「預設值」
- [x] `./mvnw test` 全部通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)